### PR TITLE
Expansion of Plotly options and add support for configuration options 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 /Manifest.toml
 .DS_Store
 empty1.jl
-empty2.jl
+customaxis.jl
+subplots3.jl
+subplots7.jl
+heatmap1.jl

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /Manifest.toml
 .DS_Store
+empty1.jl
+empty2.jl

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StipplePlotly"
 uuid = "ec984513-233d-481d-95b0-a3b58b97af2b"
 authors = ["Adrian <e@essenciary.com> and contributors"]
-version = "0.1.1"
+version = "0.2.0"
 
 [deps]
 Genie = "c43c736e-a2d1-11e8-161f-af95117fbd1e"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StipplePlotly"
 uuid = "ec984513-233d-481d-95b0-a3b58b97af2b"
 authors = ["Adrian <e@essenciary.com> and contributors"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 Genie = "c43c736e-a2d1-11e8-161f-af95117fbd1e"

--- a/docs/example1.jl
+++ b/docs/example1.jl
@@ -12,8 +12,10 @@ pd(name) = PlotData(
 Base.@kwdef mutable struct Model <: ReactiveModel
   data::R{Vector{PlotData}} = [pd("Random 1"),pd("Random 2")]
   layout::R{PlotLayout} = PlotLayout(
-    plot_bgcolor = "#333",
-    title_text = "Random numbers")
+      plot_bgcolor = "#333",
+      title = PlotLayoutTitle(text="Random numbers", font=Font(24))
+    )
+  config::R{PlotConfig} = PlotConfig()
 end
 
 model = Stipple.init(Model())
@@ -21,7 +23,7 @@ model = Stipple.init(Model())
 function ui()
   page(
     vm(model), class="container", [
-      plot(:data, layout = :layout)
+      plot(:data, layout = :layout, config = :config)
     ]
   ) |> html
 end

--- a/docs/example2.jl
+++ b/docs/example2.jl
@@ -14,8 +14,10 @@ pd(name) = PlotData(
 Base.@kwdef mutable struct Model <: ReactiveModel
   data::R{Vector{PlotData}} = [pd("Random 1"),pd("Random 2")]
   layout::R{PlotLayout} = PlotLayout(
-    plot_bgcolor = "#333",
-    title_text = "Random numbers")
+      plot_bgcolor = "#333",
+      title = PlotLayoutTitle(text="Random numbers", font=Font(24))
+    )
+  config::R{PlotConfig} = PlotConfig()
 end
 
 model = Stipple.init(Model())
@@ -23,7 +25,7 @@ model = Stipple.init(Model())
 function ui()
   page(
     vm(model), class="container", [
-      plot(:data, layout = :layout)
+      plot(:data, layout = :layout, config = :config)
     ]
   ) |> html
 end

--- a/docs/example2.jl
+++ b/docs/example2.jl
@@ -1,0 +1,33 @@
+using Genie, Genie.Renderer.Html, Stipple, StipplePlotly
+
+Genie.config.log_requests = false
+
+pd(name) = PlotData(
+  x = ["Jan2019", "Feb2019", "Mar2019", "Apr2019", "May2019",
+        "Jun2019", "Jul2019", "Aug2019", "Sep2019", "Oct2019",
+        "Nov2019", "Dec2019"],
+  y = Int[rand(1:100_000) for x in 1:12],
+  plot = StipplePlotly.Charts.PLOT_TYPE_SCATTER,
+  name = name
+)
+
+Base.@kwdef mutable struct Model <: ReactiveModel
+  data::R{Vector{PlotData}} = [pd("Random 1"),pd("Random 2")]
+  layout::R{PlotLayout} = PlotLayout(
+    plot_bgcolor = "#333",
+    title_text = "Random numbers")
+end
+
+model = Stipple.init(Model())
+
+function ui()
+  page(
+    vm(model), class="container", [
+      plot(:data, layout = :layout)
+    ]
+  ) |> html
+end
+
+route("/", ui)
+
+up()

--- a/docs/groupedbar1.jl
+++ b/docs/groupedbar1.jl
@@ -1,0 +1,68 @@
+using Genie, Genie.Renderer.Html, Stipple, StipplePlotly
+
+Genie.config.log_requests = false
+
+xx = ["start", "1d", "1w", "2w", "6w"]
+spaces = "       "
+
+# Data:
+
+y1 = [98.5, 96.0, 95.1, 94.4, 94.0]
+pb1 = PlotData(
+    x = xx, y = y1, xaxis="x", yaxis="y",
+    error_y = ErrorBar(3 .* ones(Float64,size(y1)); color="rgba(0,0,0,0.6)"),
+    plot = StipplePlotly.Charts.PLOT_TYPE_BAR, name = "Product 1",
+    text = spaces .* string.(y1), textposition="auto"
+)
+
+y2 = [99.5, 94.0, 93.1, 92.4, 92.0]
+pb2 = PlotData(
+    x = xx, y = y2, xaxis="x", yaxis="y",
+    error_y = ErrorBar(3 .* ones(Float64,size(y1)); color="rgba(0,0,0,0.6)"),
+    plot = StipplePlotly.Charts.PLOT_TYPE_BAR, name = "Product 2",
+    text = spaces .* string.(y2), textposition="auto"
+)
+
+y3 = [97.5, 92.0, 92.1, 91.4, 91.0]
+pb3 = PlotData(
+    x = xx, y = y3, xaxis="x", yaxis="y",
+    error_y = ErrorBar(3 .* ones(Float64,size(y1)); color="rgba(0,0,0,0.6)"),
+    plot = StipplePlotly.Charts.PLOT_TYPE_BAR, name = "Product 3",
+    text = spaces .* string.(y3), textposition="auto"
+)
+
+y4 = [92.5, 88.1, 87.1, 85.9, 84.0]
+pb4 = PlotData(
+    x = xx, y = y4, xaxis="x", yaxis="y",
+    error_y = ErrorBar(3 .* ones(Float64,size(y1)); color="rgba(0,0,0,0.6)"),
+    plot = StipplePlotly.Charts.PLOT_TYPE_BAR, name = "Product 4",
+    text = spaces .* string.(y4), textposition="auto"
+)
+
+plotdata = [pb1, pb2, pb3, pb4]
+
+layout = PlotLayout(barmode="group", font=Font(16),
+    title = PlotLayoutTitle(text="Product comparison", font=Font(24)),
+    xaxis = [PlotLayoutAxis(xy = "x", index = 1, title="duration", font=Font(size=24), showline = true, zeroline = false)],
+    yaxis = [PlotLayoutAxis(xy = "y", index = 1, ticks = "outside", title="ratio (%)", font=Font(size=24), autorange=false, range=[70.0,100.0], showline = true, zeroline = false)]
+)
+
+Base.@kwdef mutable struct Model <: ReactiveModel
+  data::R{Vector{PlotData}} = plotdata, READONLY
+  layout::R{PlotLayout} = layout, READONLY
+  config::R{PlotConfig} = PlotConfig(), READONLY
+end
+
+model = Stipple.init(Model())
+
+function ui()
+  page(
+    vm(model), class="container", [
+        plot(:data, layout = :layout, config = :config)
+    ]
+  ) |> html
+end
+
+route("/", ui)
+
+up()

--- a/docs/heatmap1.jl
+++ b/docs/heatmap1.jl
@@ -1,5 +1,4 @@
 using Genie, Genie.Renderer.Html, Stipple, StipplePlotly, Colors, ColorSchemes
-# using StippleCharts, Plots
 
 Genie.config.log_requests = false
 

--- a/docs/heatmap1.jl
+++ b/docs/heatmap1.jl
@@ -1,0 +1,118 @@
+using Genie, Genie.Renderer.Html, Stipple, StipplePlotly, Colors, ColorSchemes
+# using StippleCharts, Plots
+
+Genie.config.log_requests = false
+
+plotly_palette = ["Greys", "YlGnBu", "Greens", "YlOrRd", "Bluered", "RdBu", "Reds", "Blues", "Picnic", "Rainbow", "Portland", "Jet", "Hot", "Blackbody", "Earth", "Electric", "Viridis", "Cividis"]
+
+"""
+Plotly:
+  Map missing, nothing, NaN, -Inf and Inf in a string "null".
+  JSON.json maps those on null without quoutes. Call-back error occors on front-end when you write new data (as in model[].z)
+  Strings are interpreted as numbers.
+
+  Colorscale:
+    rgb triplets are strings on front-end side.
+    rgb(r,g,b) triplets: r, g and b are integers from 0 to 255, or floats from 0.0 to 1.0.
+    Floats must have a decimal for correct interpretation by Plotly.
+"""
+
+function rgb(pix::RGB{Float64})
+  R = clamp(pix.r, 0.0, 1.0)
+  G = clamp(pix.g, 0.0, 1.0)
+  B = clamp(pix.b, 0.0, 1.0)
+  return "rgb($R,$G,$B)"
+end
+
+# See: https://juliagraphics.github.io/ColorSchemes.jl/stable/basics/
+function ColorScale(scheme::Symbol, N = 101)
+  x = permutedims(0.0:(1.0/(N - 1)):1.0)
+  cs = get(colorschemes[scheme], x, :clamp)
+  cs_rgb = rgb.(cs)
+  return vcat(x, cs_rgb)
+end
+
+function to_plotly_standard(x)
+  if isnothing(x)
+    m = "null"
+  elseif ismissing(x)
+    m = "null"
+  elseif isa(x, AbstractString)
+    m = x
+  elseif isinf(x)
+    m = "null"
+  elseif isnan(x)
+    m = "null"
+  else
+    m = x
+  end
+  return m
+end
+
+pd(name) = PlotData(
+  z =  to_plotly_standard.(round.([100.0 0.0  missing;
+       30.30235455584154  94.9495352852204 0.7150792978758869;
+       63.172349721957175 37 -72.02122607433563;
+       51.19876097916769  18.676411380287483 314.15;
+       87.03992589163836  88.74217734803698 62.122844059857215]; sigdigits=3)),
+  zmin = 0.0,
+  zmax = 100.0,
+  x = ["L0", "L63", "L128", "L191", "L255"],
+  y = ["L255", "L128", "L0"],
+  plot = StipplePlotly.Charts.PLOT_TYPE_HEATMAP,
+  name = name,
+  colorscale = ColorScale(:vik),
+  colorbar = ColorBar("Z-data", 18, "right"),
+  hoverongaps = false,
+  # hovertemplate = "%{z:\$.2f}",
+  hoverinfo = "x+y+z"
+)
+
+pl(title) = PlotLayout(
+  plot_bgcolor = "#FFFFFF",
+  title_text = title,
+  margin_b = 25,
+  margin_t = 80,
+  margin_l = 40,
+  margin_r = 40,
+  xaxis_text = "From",
+  xaxis_font = Font(18),
+  xaxis_ticks = "outside top",
+  xaxis_side = "top",
+  xaxis_position = 1.0,
+  xaxis_showline = true,
+  xaxis_showgrid = false,
+  xaxis_zeroline = false,
+  xaxis_mirror = "all",
+  xaxis_ticklabelposition = "outside top",
+  yaxis_showline = true,
+  yaxis_zeroline = false,
+  yaxis_mirror = "all",
+  yaxis_showgrid = false,
+  yaxis_text = "To",
+  yaxis_font = Font(18),
+  yaxis_ticks = "outside",
+  yaxis_scaleanchor = "x",
+  yaxis_scaleratio = 1,
+  yaxis_constrain = "domain",
+  yaxis_constraintoward = "top"
+)
+
+Base.@kwdef mutable struct Model <: ReactiveModel
+  data::R{Vector{PlotData}} = [pd("Random 1")], READONLY
+  layout::R{PlotLayout} = pl(""), READONLY
+end
+
+model = Stipple.init(Model())
+
+function ui()
+  page(
+    vm(model), class="container", [
+      plot(:data, layout = :layout)
+    ]
+  ) |> html
+end
+
+route("/", ui)
+
+up()

--- a/docs/heatmap1.jl
+++ b/docs/heatmap1.jl
@@ -4,18 +4,6 @@ Genie.config.log_requests = false
 
 plotly_palette = ["Greys", "YlGnBu", "Greens", "YlOrRd", "Bluered", "RdBu", "Reds", "Blues", "Picnic", "Rainbow", "Portland", "Jet", "Hot", "Blackbody", "Earth", "Electric", "Viridis", "Cividis"]
 
-"""
-Plotly:
-  Map missing, nothing, NaN, -Inf and Inf in a string "null".
-  JSON.json maps those on null without quoutes. Call-back error occors on front-end when you write new data (as in model[].z)
-  Strings are interpreted as numbers.
-
-  Colorscale:
-    rgb triplets are strings on front-end side.
-    rgb(r,g,b) triplets: r, g and b are integers from 0 to 255, or floats from 0.0 to 1.0.
-    Floats must have a decimal for correct interpretation by Plotly.
-"""
-
 function rgb(pix::RGB{Float64})
   R = round(Int, 255 * clamp(pix.r, 0.0, 1.0))
   G = round(Int, 255 * clamp(pix.g, 0.0, 1.0))
@@ -68,37 +56,40 @@ pd(name) = PlotData(
 
 pl(title) = PlotLayout(
   plot_bgcolor = "#FFFFFF",
-  title_text = title,
+  title = PlotLayoutTitle(text=title, font=Font(24)),
   margin_b = 25,
   margin_t = 80,
-  margin_l = 40,
+  margin_l = 80,
   margin_r = 40,
-  xaxis_text = "From",
-  xaxis_font = Font(18),
-  xaxis_ticks = "outside top",
-  xaxis_side = "top",
-  xaxis_position = 1.0,
-  xaxis_showline = true,
-  xaxis_showgrid = false,
-  xaxis_zeroline = false,
-  xaxis_mirror = "all",
-  xaxis_ticklabelposition = "outside top",
-  yaxis_showline = true,
-  yaxis_zeroline = false,
-  yaxis_mirror = "all",
-  yaxis_showgrid = false,
-  yaxis_text = "To",
-  yaxis_font = Font(18),
-  yaxis_ticks = "outside",
-  yaxis_scaleanchor = "x",
-  yaxis_scaleratio = 1,
-  yaxis_constrain = "domain",
-  yaxis_constraintoward = "top"
+  xaxis = [PlotLayoutAxis(xy = "x", index = 1,
+    title = "From",
+    font = Font(18),
+    ticks = "outside top",
+    side = "top",
+    position = 1.0,
+    showline = true,
+    showgrid = false,
+    zeroline = false,
+    mirror = "all",
+    ticklabelposition = "outside top")],
+  yaxis = [PlotLayoutAxis(xy = "y", index = 1,
+    showline = true,
+    zeroline = false,
+    mirror = "all",
+    showgrid = false,
+    title = "To",
+    font = Font(18),
+    ticks = "outside",
+    scaleanchor = "x",
+    scaleratio = 1,
+    constrain = "domain",
+    constraintoward = "top")],
 )
 
 Base.@kwdef mutable struct Model <: ReactiveModel
   data::R{Vector{PlotData}} = [pd("Random 1")], READONLY
   layout::R{PlotLayout} = pl(""), READONLY
+  config::R{PlotConfig} = PlotConfig(), READONLY
 end
 
 model = Stipple.init(Model())
@@ -106,7 +97,7 @@ model = Stipple.init(Model())
 function ui()
   page(
     vm(model), class="container", [
-      plot(:data, layout = :layout)
+      plot(:data, layout = :layout, config = :config)
     ]
   ) |> html
 end

--- a/docs/heatmap2.jl
+++ b/docs/heatmap2.jl
@@ -89,38 +89,41 @@ pd(name, x, y, z; zmin = 0.0, zmax = 100.0, cs = cs) = PlotData(
 
 pl(title; annotations::Union{Nothing, Vector{PlotAnnotation}} = nothing) = PlotLayout(
   plot_bgcolor = "#FFFFFF",
-  title_text = title,
+  title = PlotLayoutTitle(text=title, font=Font(24)),
   margin_b = 25,
   margin_t = 80,
-  margin_l = 40,
+  margin_l = 60,
   margin_r = 40,
-  xaxis_text = "From",
-  xaxis_font = Font(18),
-  xaxis_ticks = "outside top",
-  xaxis_side = "top",
-  xaxis_position = 1.0,
-  xaxis_showline = true,
-  xaxis_showgrid = false,
-  xaxis_zeroline = false,
-  xaxis_mirror = "all",
-  xaxis_ticklabelposition = "outside top",
-  yaxis_showline = true,
-  yaxis_zeroline = false,
-  yaxis_mirror = "all",
-  yaxis_showgrid = false,
-  yaxis_text = "To",
-  yaxis_font = Font(18),
-  yaxis_ticks = "outside",
-  yaxis_scaleanchor = "x",
-  yaxis_scaleratio = 1,
-  yaxis_constrain = "domain",
-  yaxis_constraintoward = "top",
+  xaxis = [PlotLayoutAxis(xy = "x", index = 1,
+    title = "From",
+    font = Font(18),
+    ticks = "outside top",
+    side = "top",
+    position = 1.0,
+    showline = true,
+    showgrid = false,
+    zeroline = false,
+    mirror = "all",
+    ticklabelposition = "outside top")],
+  yaxis = [PlotLayoutAxis(xy = "y", index = 1,
+    showline = true,
+    zeroline = false,
+    mirror = "all",
+    showgrid = false,
+    title = "To",
+    font = Font(18),
+    ticks = "outside",
+    scaleanchor = "x",
+    scaleratio = 1,
+    constrain = "domain",
+    constraintoward = "top")],
   annotations = annotations
 )
 
 Base.@kwdef mutable struct Model <: ReactiveModel
   data::R{Vector{PlotData}} = [pd("Random 1", xx, yy, zz)], READONLY
   layout::R{PlotLayout} = pl(""; annotations=anv), READONLY
+  config::R{PlotConfig} = PlotConfig(), READONLY
 end
 
 model = Stipple.init(Model())
@@ -128,7 +131,7 @@ model = Stipple.init(Model())
 function ui()
   page(
     vm(model), class="container", [
-      plot(:data, layout = :layout)
+      plot(:data, layout = :layout, config = :config)
     ]
   ) |> html
 end

--- a/docs/heatmap2.jl
+++ b/docs/heatmap2.jl
@@ -2,20 +2,6 @@ using Genie, Genie.Renderer.Html, Stipple, StipplePlotly, Colors, ColorSchemes
 
 Genie.config.log_requests = false
 
-plotly_palette = ["Greys", "YlGnBu", "Greens", "YlOrRd", "Bluered", "RdBu", "Reds", "Blues", "Picnic", "Rainbow", "Portland", "Jet", "Hot", "Blackbody", "Earth", "Electric", "Viridis", "Cividis"]
-
-"""
-Plotly:
-  Map missing, nothing, NaN, -Inf and Inf in a string "null".
-  JSON.json maps those on null without quoutes. Call-back error occors on front-end when you write new data (as in model[].z)
-  Strings are interpreted as numbers.
-
-  Colorscale:
-    rgb triplets are strings on front-end side.
-    rgb(r,g,b) triplets: r, g and b are integers from 0 to 255, or floats from 0.0 to 1.0.
-    Floats must have a decimal for correct interpretation by Plotly.
-"""
-
 function rgb(pix::RGB{Float64})
   R = round(Int, 255 * clamp(pix.r, 0.0, 1.0))
   G = round(Int, 255 * clamp(pix.g, 0.0, 1.0))
@@ -48,25 +34,60 @@ function to_plotly_standard(x)
   return m
 end
 
-pd(name) = PlotData(
-  z =  to_plotly_standard.(round.([100.0 0.0  missing;
-       30.30235455584154  94.9495352852204 0.7150792978758869;
+xx = ["L0", "L63", "L128", "L191", "L255"]
+yy = ["L255", "L128", "L0"]
+zz = [ 100.0 0.0  missing;
+       31.30235455584154  94.9495352852204 0.7150792978758869;
        63.172349721957175 37 -72.02122607433563;
        51.19876097916769  18.676411380287483 314.15;
-       87.03992589163836  88.74217734803698 62.122844059857215]; sigdigits=3)),
-  zmin = 0.0,
-  zmax = 100.0,
-  x = ["L0", "L63", "L128", "L191", "L255"],
-  y = ["L255", "L128", "L0"],
+       87.03992589163836  88.74217734803698 62.122844059857215];
+
+cs = :algae # color scheme
+
+function textcolor_mask(z,zmin,zmax,cs; halfluminance=(0.5^2.2))
+  m = zeros(Float64, size(z))
+  for i=1:length(m)
+    if !ismissing(z[i])
+      c = get(colorschemes[cs], Float64(z[i]), (zmin,zmax))
+      if xyY(c).Y < halfluminance
+        m[i] = 1.0
+      end
+    end
+  end
+  m
+end
+
+function annotate_map(x, y, z, zmin, zmax, cs)
+  m = textcolor_mask(z,zmin,zmax,cs; halfluminance=(0.5^2.2))
+  anv = Vector{PlotAnnotation}(undef, 0)
+  anv = PlotAnnotation[]
+  for i=1:size(z,1)
+    for j=1:size(z,2)
+      c = rgb(RGB(m[i,j], m[i,j], m[i,j]))
+      an = PlotAnnotation(visible=!ismissing(z[i,j]), x=x[i], y=y[j], xref="x", yref="y", text= "$(round(z[i,j]; sigdigits=3))", ax=0, ay=0, showarrow=false, font=Font(color=c, size=16) )
+      push!(anv, an)
+    end
+  end
+  anv
+end
+
+anv = annotate_map(xx, yy, zz, 0.0, 100.0, cs);
+
+pd(name, x, y, z; zmin = 0.0, zmax = 100.0, cs = cs) = PlotData(
+  z =  to_plotly_standard.(round.(z; sigdigits=3)),
+  zmin = zmin,
+  zmax = zmax,
+  x = x,
+  y = y,
   plot = StipplePlotly.Charts.PLOT_TYPE_HEATMAP,
   name = name,
-  colorscale = ColorScale(:algae),
+  colorscale = ColorScale(cs),
   colorbar = ColorBar("Z-data", 18, "right"),
   hoverongaps = false,
   hoverinfo = "x+y+z"
 )
 
-pl(title) = PlotLayout(
+pl(title; annotations::Union{Nothing, Vector{PlotAnnotation}} = nothing) = PlotLayout(
   plot_bgcolor = "#FFFFFF",
   title_text = title,
   margin_b = 25,
@@ -93,12 +114,13 @@ pl(title) = PlotLayout(
   yaxis_scaleanchor = "x",
   yaxis_scaleratio = 1,
   yaxis_constrain = "domain",
-  yaxis_constraintoward = "top"
+  yaxis_constraintoward = "top",
+  annotations = annotations
 )
 
 Base.@kwdef mutable struct Model <: ReactiveModel
-  data::R{Vector{PlotData}} = [pd("Random 1")], READONLY
-  layout::R{PlotLayout} = pl(""), READONLY
+  data::R{Vector{PlotData}} = [pd("Random 1", xx, yy, zz)], READONLY
+  layout::R{PlotLayout} = pl(""; annotations=anv), READONLY
 end
 
 model = Stipple.init(Model())

--- a/docs/multitype1.jl
+++ b/docs/multitype1.jl
@@ -34,25 +34,32 @@ pd_scatter(name, xar, dx, yar, dy) = PlotData(
 
 pl() = PlotLayout(
   plot_bgcolor = "#FFFFFF",
-  title_text = "Wave",
+  title = PlotLayoutTitle(text="Wave", font=Font(24)),
+  legend = PlotLayoutLegend(bgcolor = "rgb(212,212,212)", font=Font(6)),
   hovermode = "closest",
   showlegend = true,
-  xaxis_text = "time (s)",
-  yaxis_text = "displacement (mm)",
-  yaxis_ticks = "outside",
-  xaxis_ticks = "outside",
-  xaxis_showline = true,
-  yaxis_showline = true,
-  yaxis_zeroline = false,
-  xaxis_zeroline = false,
-  xaxis_mirror = "all",
-  yaxis_mirror = "all",
+  xaxis = [PlotLayoutAxis(xy="x", index=1,
+    title = "time (s)",
+    ticks = "outside",
+    tickfont = Font(size=24, color="#FF00FF"),
+    showline = true,
+    zeroline = false,
+    mirror = true
+  )],
+  yaxis = [PlotLayoutAxis(xy="y", index=1,
+    showline = true,
+    zeroline = false,
+    title = "displacement (mm)",
+    ticks = "outside",
+    mirror = true
+  )],
   annotations = [PlotAnnotation(visible=true, x=xexperiment[6], y=yexperiment[6], text="possible outlier")]
 )
 
 Base.@kwdef mutable struct Model <: ReactiveModel
   data::R{Vector{PlotData}} = [pd_line("Sinus", xrange), pd_scatter("Experiment", xexperiment, dx, yexperiment, dy)]
   layout::R{PlotLayout} = pl()
+  config::R{PlotConfig} = PlotConfig()
 end
 
 model = Stipple.init(Model())
@@ -60,7 +67,7 @@ model = Stipple.init(Model())
 function ui()
   page(
     vm(model), class="container", [
-        plot(:data, layout = :layout)
+        plot(:data, layout = :layout, config = :config)
     ]
   ) |> html
 end

--- a/docs/multitype1.jl
+++ b/docs/multitype1.jl
@@ -11,6 +11,8 @@ xexperiment = (0.0:(2π/10):2π) .+ 3 .* dxmeasured .* (rand(Float64,11) .- 0.5)
 dx = dxmeasured .* ones(Float64, size(xexperiment))
 yexperiment = sin.(xexperiment) .+ 3 .* dymeasured .* (rand(Float64,size(xexperiment)) .- 0.5)
 dy = dymeasured .* ones(Float64, size(yexperiment))
+# create outlier:
+yexperiment[6] = 0.5
 
 pd_line(name, xar) = PlotData(
   x = xar,
@@ -44,9 +46,8 @@ pl() = PlotLayout(
   yaxis_zeroline = false,
   xaxis_zeroline = false,
   xaxis_mirror = "all",
-  yaxis_mirror = "all"
-  # height = nothing,
-  # width = nothing
+  yaxis_mirror = "all",
+  annotations = [PlotAnnotation(visible=true, x=xexperiment[6], y=yexperiment[6], text="possible outlier")]
 )
 
 Base.@kwdef mutable struct Model <: ReactiveModel

--- a/docs/multitype1.jl
+++ b/docs/multitype1.jl
@@ -30,25 +30,28 @@ pd_scatter(name, xar, dx, yar, dy) = PlotData(
   name = name
 )
 
+pl() = PlotLayout(
+  plot_bgcolor = "#FFFFFF",
+  title_text = "Wave",
+  hovermode = "closest",
+  showlegend = true,
+  xaxis_text = "time (s)",
+  yaxis_text = "displacement (mm)",
+  yaxis_ticks = "outside",
+  xaxis_ticks = "outside",
+  xaxis_showline = true,
+  yaxis_showline = true,
+  yaxis_zeroline = false,
+  xaxis_zeroline = false,
+  xaxis_mirror = "all",
+  yaxis_mirror = "all"
+  # height = nothing,
+  # width = nothing
+)
+
 Base.@kwdef mutable struct Model <: ReactiveModel
   data::R{Vector{PlotData}} = [pd_line("Sinus", xrange), pd_scatter("Experiment", xexperiment, dx, yexperiment, dy)]
-  layout::R{PlotLayout} = PlotLayout(
-    plot_bgcolor = "#FFFFFF",
-    title_text = "Wave",
-    hovermode = "closest",
-    showlegend = true,
-    xaxis_text = "time (s)",
-    yaxis_text = "displacement (mm)",
-    yaxis_ticks = "outside",
-    xaxis_ticks = "outside",
-    xaxis_showline = true,
-    yaxis_showline = true,
-    yaxis_zeroline = false,
-    xaxis_zeroline = false,
-    xaxis_mirror = "all",
-    yaxis_mirror = "all",
-    width = 850,
-    height = 450)
+  layout::R{PlotLayout} = pl()
 end
 
 model = Stipple.init(Model())

--- a/docs/multitype1.jl
+++ b/docs/multitype1.jl
@@ -1,0 +1,66 @@
+using Genie, Genie.Renderer.Html, Stipple, StipplePlotly
+
+Genie.config.log_requests = false
+
+xrange = 0.0:(2π/1000):2π
+
+dxmeasured = 0.05
+dymeasured = 0.1
+
+xexperiment = (0.0:(2π/10):2π) .+ 3 .* dxmeasured .* (rand(Float64,11) .- 0.5)
+dx = dxmeasured .* ones(Float64, size(xexperiment))
+yexperiment = sin.(xexperiment) .+ 3 .* dymeasured .* (rand(Float64,size(xexperiment)) .- 0.5)
+dy = dymeasured .* ones(Float64, size(yexperiment))
+
+pd_line(name, xar) = PlotData(
+  x = xar,
+  y = sin.(xar),
+  plot = StipplePlotly.Charts.PLOT_TYPE_SCATTER,
+  mode = "lines",
+  name = name
+)
+
+pd_scatter(name, xar, dx, yar, dy) = PlotData(
+  x = xar,
+  error_x = ErrorBar(dx),
+  y = yar,
+  error_y = ErrorBar(dy),
+  plot = StipplePlotly.Charts.PLOT_TYPE_SCATTER,
+  mode = "markers",
+  name = name
+)
+
+Base.@kwdef mutable struct Model <: ReactiveModel
+  data::R{Vector{PlotData}} = [pd_line("Sinus", xrange), pd_scatter("Experiment", xexperiment, dx, yexperiment, dy)]
+  layout::R{PlotLayout} = PlotLayout(
+    plot_bgcolor = "#FFFFFF",
+    title_text = "Wave",
+    hovermode = "closest",
+    showlegend = true,
+    xaxis_text = "time (s)",
+    yaxis_text = "displacement (mm)",
+    yaxis_ticks = "outside",
+    xaxis_ticks = "outside",
+    xaxis_showline = true,
+    yaxis_showline = true,
+    yaxis_zeroline = false,
+    xaxis_zeroline = false,
+    xaxis_mirror = "all",
+    yaxis_mirror = "all",
+    width = 850,
+    height = 450)
+end
+
+model = Stipple.init(Model())
+
+function ui()
+  page(
+    vm(model), class="container", [
+        plot(:data, layout = :layout)
+    ]
+  ) |> html
+end
+
+route("/", ui)
+
+up()

--- a/docs/subplots2x2.jl
+++ b/docs/subplots2x2.jl
@@ -1,0 +1,91 @@
+using Genie, Genie.Renderer.Html, Stipple, StipplePlotly
+
+Genie.config.log_requests = false
+
+xx = -π:(2π/250):π
+
+xxs = -3.0:0.2:3.0
+
+# Data:
+
+pl1 = PlotData(
+    x = xx, y = sin.(xx), plot = StipplePlotly.Charts.PLOT_TYPE_SCATTER,
+    name = "sine", mode = "lines", xaxis = "x", yaxis = "y", line = PlotDataLine(color = "rgb(0,0,192)", dash="solid")
+)
+
+pl2 = PlotData(
+    x = xx, y = sinh.(xx), plot = StipplePlotly.Charts.PLOT_TYPE_SCATTER,
+    name = "sinh", mode = "lines", xaxis = "x2", yaxis = "y2", line = PlotDataLine(color = "rgb(0,192,0)", dash="dot")
+)
+
+pl3 = PlotData(
+    x = xx, y = cos.(xx), plot = StipplePlotly.Charts.PLOT_TYPE_SCATTER,
+    name = "cosine", mode = "lines", xaxis = "x3", yaxis = "y3", line = PlotDataLine(color = "rgb(192,0,0)", dash="dash")
+)
+
+pl4 = PlotData(
+    x = xx, y = cosh.(xx), plot = StipplePlotly.Charts.PLOT_TYPE_SCATTER,
+    name = "cosh", mode = "lines", xaxis = "x4", yaxis = "y4", line = PlotDataLine(color = "rgb(192,0,192)", dash="dashdot")
+)
+
+ps1 = PlotData(
+    x = xxs, y = sin.(xxs) .+ rand(Float64, size(xxs)) .- 0.5, plot = StipplePlotly.Charts.PLOT_TYPE_SCATTER,
+    name = "sine", mode = "markers", xaxis = "x", yaxis = "y", marker = PlotDataMarker(color="rgb(0,0,192)", symbol="circle", size=10, opacity=0.5)
+)
+
+ps2 = PlotData(
+    x = xxs, y = sinh.(xxs) .+ 3.0 .* rand(Float64, size(xxs)) .- 1.5, plot = StipplePlotly.Charts.PLOT_TYPE_SCATTER,
+    name = "sinh", mode = "markers", xaxis = "x2", yaxis = "y2", marker = PlotDataMarker(color = "rgb(0,192,0)", symbol="circle-open", size=14)
+)
+
+ps3 = PlotData(
+    x = xxs, y = cos.(xxs) .+ rand(Float64, size(xxs)) .- 0.5, plot = StipplePlotly.Charts.PLOT_TYPE_SCATTER,
+    name = "cosine", mode = "markers", xaxis = "x3", yaxis = "y3", marker = PlotDataMarker(color = "rgb(192,0,0)", symbol="diamond", size=10, opacity=0.5)
+)
+
+ps4 = PlotData(
+    x = xxs, y = cosh.(xxs) .+ 3.0 .* rand(Float64, size(xxs)) .- 1.5, plot = StipplePlotly.Charts.PLOT_TYPE_SCATTER,
+    name = "cosh", mode = "markers", xaxis = "x4", yaxis = "y4", marker = PlotDataMarker(color = "rgb(192,0,192)", symbol="diamond-open", size=3)
+)
+
+plotdata = [ps1, ps2, ps3, ps4, pl1, pl2, pl3, pl4];
+
+# Layout
+
+layout = PlotLayout(
+    title = PlotLayoutTitle(text="Multiple Mixed Subplots", font=Font(24)),
+    showlegend = false,
+    grid = PlotLayoutGrid(rows = 2, columns = 2, pattern = "independent"),
+    xaxis = [
+        PlotLayoutAxis(xy = "x", index = 1, ticks = "outside", showline = true, zeroline = false),
+        PlotLayoutAxis(xy = "x", index = 2, ticks = "outside", showline = true, zeroline = false),
+        PlotLayoutAxis(xy = "x", index = 3, ticks = "outside", showline = true, zeroline = false, title="range (arb. units)"),
+        PlotLayoutAxis(xy = "x", index = 4, ticks = "outside", showline = true, zeroline = false, title="range (arb. units)")
+    ],
+    yaxis = [
+        PlotLayoutAxis(xy = "y", index = 1, ticks = "outside", showline = true, zeroline = false, title="response A"),
+        PlotLayoutAxis(xy = "y", index = 2, ticks = "outside", showline = true, zeroline = false, title="response B"),
+        PlotLayoutAxis(xy = "y", index = 3, ticks = "outside", showline = true, zeroline = false, title="response C"),
+        PlotLayoutAxis(xy = "y", index = 4, ticks = "outside", showline = true, zeroline = false, title="response D")
+    ],
+)
+
+Base.@kwdef mutable struct Model <: ReactiveModel
+  data::R{Vector{PlotData}} = plotdata, READONLY
+  layout::R{PlotLayout} = layout, READONLY
+  config::R{PlotConfig} = PlotConfig(), READONLY
+end
+
+model = Stipple.init(Model())
+
+function ui()
+  page(
+    vm(model), class="container", [
+        plot(:data, layout = :layout, config = :config)
+    ]
+  ) |> html
+end
+
+route("/", ui)
+
+up()

--- a/docs/subplots2x2.jl
+++ b/docs/subplots2x2.jl
@@ -10,22 +10,22 @@ xxs = -3.0:0.2:3.0
 
 pl1 = PlotData(
     x = xx, y = sin.(xx), plot = StipplePlotly.Charts.PLOT_TYPE_SCATTER,
-    name = "sine", mode = "lines", xaxis = "x", yaxis = "y", line = PlotDataLine(color = "rgb(0,0,192)", dash="solid")
+    name = "sine", mode = "lines", xaxis = "x", yaxis = "y", line = PlotlyLine(color = "rgb(0,0,192)", dash="solid")
 )
 
 pl2 = PlotData(
     x = xx, y = sinh.(xx), plot = StipplePlotly.Charts.PLOT_TYPE_SCATTER,
-    name = "sinh", mode = "lines", xaxis = "x2", yaxis = "y2", line = PlotDataLine(color = "rgb(0,192,0)", dash="dot")
+    name = "sinh", mode = "lines", xaxis = "x2", yaxis = "y2", line = PlotlyLine(color = "rgb(0,192,0)", dash="dot")
 )
 
 pl3 = PlotData(
     x = xx, y = cos.(xx), plot = StipplePlotly.Charts.PLOT_TYPE_SCATTER,
-    name = "cosine", mode = "lines", xaxis = "x3", yaxis = "y3", line = PlotDataLine(color = "rgb(192,0,0)", dash="dash")
+    name = "cosine", mode = "lines", xaxis = "x3", yaxis = "y3", line = PlotlyLine(color = "rgb(192,0,0)", dash="dash")
 )
 
 pl4 = PlotData(
     x = xx, y = cosh.(xx), plot = StipplePlotly.Charts.PLOT_TYPE_SCATTER,
-    name = "cosh", mode = "lines", xaxis = "x4", yaxis = "y4", line = PlotDataLine(color = "rgb(192,0,192)", dash="dashdot")
+    name = "cosh", mode = "lines", xaxis = "x4", yaxis = "y4", line = PlotlyLine(color = "rgb(192,0,192)", dash="dashdot")
 )
 
 ps1 = PlotData(

--- a/files/js/vueplotly.js
+++ b/files/js/vueplotly.js
@@ -76,6 +76,9 @@ Vue.component('plotly', {
     layout: {
       type: Object
     },
+    config: {
+      type: Object
+    },
     id: {
       type: String,
       required: false,
@@ -85,7 +88,8 @@ Vue.component('plotly', {
   data() {
     return {
       scheduled: null,
-      innerLayout: { ...this.layout }
+      innerLayout: { ...this.layout },
+      options: { ...this.config }
     };
   },
   mounted() {
@@ -102,30 +106,13 @@ Vue.component('plotly', {
       },
       deep: true
     },
-    options: {
-      handler(value, old) {
-        if (JSON.stringify(value) === JSON.stringify(old)) {
-          return;
-        }
-        this.schedule({ replot: true });
-      },
-      deep: true
-    },
     layout(layout) {
       this.innerLayout = { ...layout };
       this.schedule({ replot: false });
-    }
-  },
-  computed: {
-    options() {
-      const optionsFromAttrs = Object.keys(this.$attrs).reduce((acc, key) => {
-        acc[camelize(key)] = this.$attrs[key];
-        return acc;
-      }, {});
-      return {
-        responsive: false,
-        ...optionsFromAttrs
-      };
+    },
+    config(config) {
+      this.options = { ...config };
+      this.schedule({ replot: false });
     }
   },
   beforeDestroy() {

--- a/src/Charts.jl
+++ b/src/Charts.jl
@@ -69,6 +69,11 @@ Base.@kwdef mutable struct Font
   color::String = "#444"
 end
 
+Base.:(==)(x::Font, y::Font) = x.family == y.family && x.size == y.size && x.color == y.color
+
+
+Base.hash(f::Font) = hash("$(f.family)$(f.size)$(f.color)")
+
 Base.@kwdef mutable struct PlotLayout
   title_text::String = ""
   title_font::Font = Font()
@@ -198,6 +203,20 @@ Base.@kwdef mutable struct PlotLayout
   extendsunburstcolors::Bool = true
   # TODO: treemapcolorway
   extendtreemapcolors::Bool = true
+end
+
+
+function Base.show(io::IO, l::PlotLayout)
+  default = PlotLayout()
+  output = "layout: \n"
+  for f in fieldnames(typeof(l))
+    prop = getproperty(l, f)
+    if prop != getproperty(default, f)
+      output *= "$f = $prop \n"
+    end
+  end
+
+  print(output)
 end
 
 Base.@kwdef mutable struct PlotData

--- a/src/Charts.jl
+++ b/src/Charts.jl
@@ -6,6 +6,8 @@ import Genie.Renderer.Html: HTMLString, normal_element
 using Stipple
 
 export PlotLayout, PlotData, PlotAnnotation, Trace, plot, ErrorBar, Font, ColorBar
+export PlotLayoutGrid, PlotLayoutAxis
+export PlotConfig, PlotLayoutTitle, PlotLayoutLegend, PlotDataLine, PlotDataMarker
 
 const DEFAULT_WRAPPER = Genie.Renderer.Html.template
 
@@ -59,7 +61,6 @@ const LAYOUT_BELOW = "below"
 const LAYOUT_OVERLAY = "overlay"
 const LAYOUT_GROUP = "group"
 const LAYOUT_STACK = "stack"
-
 
 Genie.Renderer.Html.register_normal_element("plotly", context = @__MODULE__)
 
@@ -183,7 +184,7 @@ function Base.show(io::IO, an::PlotAnnotation)
     end
   end
 
-  print(output)
+  print(io, output)
 end
 
 function Base.Dict(an::PlotAnnotation)
@@ -223,112 +224,305 @@ function Stipple.render(anv::Vector{PlotAnnotation}, fieldname::Union{Symbol,Not
   [Dict(an) for an in anv]
 end
 
+#===#
+
+Base.@kwdef mutable struct PlotLayoutGrid
+  rows::Union{Int,Nothing} = nothing # >= 1
+  roworder::Union{String,Nothing} = nothing # "top to bottom" | "bottom to top"
+  columns::Union{Int,Nothing} = nothing # >= 1
+  subplots::Union{Matrix{String},Nothing} = nothing
+  xaxes::Union{Vector{String},Nothing} = nothing
+  yaxes::Union{Vector{String},Nothing} = nothing
+  pattern::Union{String,Nothing} = nothing # "independent" | "coupled"
+  xgap::Union{Float64,Nothing} = nothing # [0.0, 1.0]
+  ygap::Union{Float64,Nothing} = nothing # [0.0, 1.0]
+  domain_x::Union{Vector{Float64},Nothing} = nothing # fraction, e.g [0, 1]
+  domain_y::Union{Vector{Float64},Nothing} = nothing # fraction, e.g [0, 1]
+  xside::Union{String,Nothing} = nothing # "bottom" | "bottom plot" | "top plot" | "top"
+  yside::Union{String,Nothing} = nothing # "bottom" | "bottom plot" | "top plot" | "top"
+end
+
+function Base.show(io::IO, lg::PlotLayoutGrid)
+  output = "Layout Grid: \n"
+  for f in fieldnames(typeof(lg))
+    prop = getproperty(lg, f)
+    if prop !== nothing
+      output *= "$f = $prop \n"
+    end
+  end
+
+  print(io, output)
+end
+
+function Base.Dict(lg::PlotLayoutGrid)
+  trace = Dict{Symbol,Any}()
+
+  if (lg.domain_x !== nothing) & (lg.domain_y !== nothing)
+    trace[:domain] = Dict(
+      :x => lg.domain_x,
+      :y => lg.domain_y
+    )
+  elseif lg.domain_x !== nothing
+    trace[:domain] = Dict(
+      :x => lg.domain_x
+    )
+  elseif lg.domain_y !== nothing
+    trace[:domain] = Dict(
+      :y => lg.domain_y
+    )
+  end
+
+  optionals!(trace, lg, [:rows, :roworder, :columns, :subplots, :xaxes, :yaxes,
+                         :pattern, :xgap, :ygap, :xside, :yside])
+
+end
+
+function optionals!(d::Dict, lg::PlotLayoutGrid, opts::Vector{Symbol}) :: Dict
+  for o in opts
+    if getproperty(lg, o) !== nothing
+      d[o] = getproperty(lg, o)
+    end
+  end
+
+  d
+end
+
+#===#
+
+Base.@kwdef mutable struct PlotLayoutAxis
+  xy::String = "x" # "x" or "y"
+  index::Int = 1 # 1, 2, 3 etc. for subplots
+
+  title::Union{String,Nothing} = nothing # "axis title"
+  font::Union{Font,Nothing} = nothing
+  automargin::Union{Bool,Nothing} = nothing
+  ticks::Union{String,Nothing} = nothing
+  showline::Union{Bool,Nothing} = nothing
+  zeroline::Union{Bool,Nothing} = nothing
+  linecolor::Union{String,Nothing} = nothing
+  linewidth::Union{Int,Nothing} = nothing
+  mirror::Union{Bool,String,Nothing} = nothing
+  ticklabelposition::Union{String,Nothing} = nothing
+  showgrid::Union{Bool,Nothing} = nothing
+  gridcolor::Union{String,Nothing} = nothing
+  gridwidth::Union{Int,Nothing} = nothing
+  side::Union{String,Nothing} = nothing
+  anchor::Union{String,Nothing} = nothing
+  position::Union{Float64,Nothing} = nothing
+  domain::Union{Vector{Float64},Nothing} = nothing
+  scaleanchor::Union{String,Nothing} = nothing
+  scaleratio::Union{Int,Nothing} = nothing
+  constrain::Union{String,Nothing} = nothing
+  constraintoward::Union{String,Nothing} = nothing
+  autorange::Union{Bool,String,Nothing} = nothing
+  rangemode::Union{String,Nothing} = nothing
+  range::Union{Vector{Int},Vector{Float64},Nothing} = nothing
+  fixedrange::Union{Bool,Nothing} = nothing
+  type::Union{String,Nothing} = nothing
+  autotypenumbers::Union{String,Nothing} = nothing
+  tickmode::Union{String,Nothing} = nothing
+  nticks::Union{Int,Nothing} = nothing
+  tick0::Union{Float64,Int,String,Nothing} = nothing
+  dtick::Union{Float64,Int,String,Nothing} = nothing
+  tickvals::Union{Vector{Float64},Vector{Int},Nothing} = nothing
+  ticktext::Union{Vector{String},Nothing} = nothing
+  tickformat::Union{String,Nothing} = nothing
+  tickfont::Union{Font,Nothing} = nothing
+  tickangle::Union{String,Int,Float64,Nothing} = nothing
+  tickprefix::Union{String,Nothing} = nothing
+  ticksuffix::Union{String,Nothing} = nothing
+  showexponent::Union{String,Nothing} = nothing
+  minexponent::Union{Int,Nothing} = nothing
+  hoverformat::Union{String,Nothing} = nothing
+  zerolinecolor::Union{String,Nothing} = nothing
+  zerolinewidth::Union{Int,Nothing} = nothing
+  showdividers::Union{Bool,Nothing} = nothing
+  dividercolor::Union{String,Nothing} = nothing
+  dividerwidth::Union{Int,Nothing} = nothing
+  overlaying::Union{String,Nothing} = nothing
+  layer::Union{String,Nothing} = nothing
+  categoryorder::Union{String,Nothing} = nothing
+  categoryarray::Union{Vector{Float64},Nothing} = nothing
+  calendar::Union{String,Nothing} = nothing
+end
+
+function Base.show(io::IO, la::PlotLayoutAxis)
+  output = "Layout Axis: \n"
+  for f in fieldnames(typeof(la))
+    prop = getproperty(la, f)
+    if prop !== nothing
+      output *= "$f = $prop \n"
+    end
+  end
+
+  print(io, output)
+end
+
+function Base.Dict(la::PlotLayoutAxis)
+  trace = Dict{Symbol,Any}()
+
+  d = optionals!(trace, la, [:title, :font, :automargin, :ticks, :showline, :zeroline,
+                         :linecolor, :linewidth, :mirror, :ticklabelposition, :showgrid,
+                         :gridcolor, :gridwidth, :side, :anchor, :position, :domain, :scaleanchor, :scaleratio, :constrain, :constraintoward, :autorange,
+                         :rangemode, :range, :fixedrange, :type, :autotypenumbers,
+                         :tickmode, :nticks, :tick0, :dtick, :tickvals, :ticktext, :tickformat, :tickfont,
+                         :tickangle, :tickprefix, :ticksuffix, :showexponent, :minexponent,
+                         :hoverformat, :zerolinecolor, :zerolinewidth, :showdividers, :dividercolor,
+                         :dividerwidth, :overlaying, :layer, :categoryorder, :categoryarray, :calendar])
+
+  k = Symbol(la.xy * "axis" * ((la.index > 1) ? "$(la.index)" : ""))
+  Dict(k => d)
+end
+
+function optionals!(d::Dict, la::PlotLayoutAxis, opts::Vector{Symbol}) :: Dict
+  for o in opts
+    if getproperty(la, o) !== nothing
+      d[o] = getproperty(la, o)
+    end
+  end
+
+  d
+end
+
+function Stipple.render(la::PlotLayoutAxis, fieldname::Union{Symbol,Nothing} = nothing)
+  [Dict(la)]
+end
+
+function Stipple.render(lav::Vector{PlotLayoutAxis}, fieldname::Union{Symbol,Nothing} = nothing)
+  [Dict(la) for la in lav]
+end
+
+#===#
+
+Base.@kwdef mutable struct PlotLayoutTitle
+  text::Union{String,Nothing} = nothing # ""
+  font::Union{Font,Nothing} = nothing # Font()
+  xref::Union{String,Nothing} = nothing # LAYOUT_TITLE_REF_CONTAINER
+  yref::Union{String,Nothing} = nothing # LAYOUT_TITLE_REF_CONTAINER
+  x::Union{Float64,String,Nothing} = nothing # 0.5
+  y::Union{Float64,String,Nothing} = nothing # LAYOUT_AUTO
+  xanchor::Union{String,Nothing} = nothing # LAYOUT_AUTO
+  yanchor::Union{String,Nothing} = nothing # LAYOUT_AUTO
+  pad_t::Union{Int,Nothing} = nothing # 0
+  pad_r::Union{Int,Nothing} = nothing # 0
+  pad_b::Union{Int,Nothing} = nothing # 0
+  pad_l::Union{Int,Nothing} = nothing # 0
+end
+
+function Base.show(io::IO, plt::PlotLayoutTitle)
+  output = "Layout Title: \n"
+  for f in fieldnames(typeof(plt))
+    prop = getproperty(plt, f)
+    if prop !== nothing
+      output *= "$f = $prop \n"
+    end
+  end
+
+  print(io, output)
+end
+
+function Base.Dict(plt::PlotLayoutTitle)
+  trace = Dict{Symbol, Any}()
+
+  d = Dict{Symbol, Any}()
+  (plt.pad_t !== nothing) && (d[:t] = plt.pad_t)
+  (plt.pad_r !== nothing) && (d[:r] = plt.pad_r)
+  (plt.pad_b !== nothing) && (d[:b] = plt.pad_b)
+  (plt.pad_l !== nothing) && (d[:l] = plt.pad_l)
+  (length(d) > 0) && (trace[:pad] = d)
+
+  optionals!(trace, plt, [:text, :font, :xref, :yref, :x, :y, :xanchor, :yanchor])
+end
+
+function optionals!(d::Dict, plt::PlotLayoutTitle, opts::Vector{Symbol}) :: Dict
+  for o in opts
+    if getproperty(plt, o) !== nothing
+      d[o] = getproperty(plt, o)
+    end
+  end
+
+  d
+end
+
+function Stipple.render(plt::PlotLayoutTitle, fieldname::Union{Symbol,Nothing} = nothing)
+  Dict(plt)
+end
+
+#===#
+
+Base.@kwdef mutable struct PlotLayoutLegend
+  bgcolor::Union{String,Nothing} = nothing
+  bordercolor::Union{String,Nothing} = nothing # "#444"
+  borderwidth::Union{Int,Nothing} = nothing # 0
+  font::Union{Font,Nothing} = nothing # Font()
+  orientation::Union{String,Nothing} = nothing # LAYOUT_ORIENTATION_VERTICAL
+  traceorder::Union{String,Nothing} = nothing # "normal"
+  tracegroupgap::Union{Int,Nothing} = nothing # 10
+  itemsizing::Union{String,Nothing} = nothing # LAYOUT_ITEMSIZING_TRACE
+  itemwidth::Union{Int,Nothing} = nothing # 30
+  itemclick::Union{String,Bool,Nothing} = nothing # LAYOUT_CLICK_TOGGLE
+  itemdoubleclick::Union{String,Bool,Nothing} = nothing #  LAYOUT_CLICK_TOGGLEOTHERS
+  x::Union{Int,Float64,Nothing} = nothing # 1.02
+  xanchor::Union{String,Nothing} = nothing # LAYOUT_LEFT
+  y::Union{Int,Float64,Nothing} = nothing # 1
+  yanchor::Union{String,Nothing} = nothing # LAYOUT_AUTO
+  # TODO: uirevision::Union{Int,String} = ""
+  valign::Union{String,Nothing} = nothing # LAYOUT_MIDDLE
+  title_text::Union{String,Nothing} = nothing # ""
+  title_font::Union{Font,Nothing} = nothing # Font()
+  title_side::Union{String,Nothing} = nothing # LAYOUT_LEFT
+end
+
+function Base.show(io::IO, pll::PlotLayoutLegend)
+  output = "Layout Legend: \n"
+  for f in fieldnames(typeof(pll))
+    prop = getproperty(pll, f)
+    if prop !== nothing
+      output *= "$f = $prop \n"
+    end
+  end
+
+  print(io, output)
+end
+
+function Base.Dict(pll::PlotLayoutLegend)
+  trace = Dict{Symbol, Any}()
+
+  d = Dict{Symbol, Any}()
+  (pll.title_text !== nothing) && (d[:text] = pll.title_text)
+  (pll.title_font !== nothing) && (d[:font] = pll.title_font)
+  (pll.title_side !== nothing) && (d[:side] = pll.title_side)
+  (length(d) > 0) && (trace[:title] = d)
+
+  optionals!(trace, pll, [:bgcolor, :bordercolor, :borderwidth, :font, :orientation, :traceorder, :tracegroupgap, :itemsizing, :itemwidth, :itemclick, :itemdoubleclick, :x, :xanchor, :y, :yanchor, :valign])
+end
+
+function optionals!(d::Dict, pll::PlotLayoutLegend, opts::Vector{Symbol}) :: Dict
+  for o in opts
+    if getproperty(pll, o) !== nothing
+      d[o] = getproperty(pll, o)
+    end
+  end
+
+  d
+end
+
+function Stipple.render(pll::PlotLayoutLegend, fieldname::Union{Symbol,Nothing} = nothing)
+  Dict(pll)
+end
 
 #===#
 
 Base.@kwdef mutable struct PlotLayout
-  title_text::String = ""
-  title_font::Font = Font()
-  title_xref::String = LAYOUT_TITLE_REF_CONTAINER
-  title_yref::String = LAYOUT_TITLE_REF_CONTAINER
-  title_x::Union{Float64,String} = 0.5
-  title_y::Union{Float64,String} = LAYOUT_AUTO
-  title_xanchor::String = LAYOUT_AUTO
-  title_yanchor::String = LAYOUT_AUTO
-  title_pad_t::Int = 0
-  title_pad_r::Int = 0
-  title_pad_b::Int = 0
-  title_pad_l::Int = 0
-
-  xaxis_text::String = "x-axis"
-  xaxis_font::Font = Font()
-  xaxis_automargin::Bool = true
-  xaxis_ticks::String = "inside"
-  xaxis_showline::Bool = false
-  xaxis_zeroline::Bool = true
-  xaxis_linecolor::String = "#444"
-  xaxis_linewidth::Int = 1
-  xaxis_mirror::Union{Bool, String} = false
-  xaxis_ticklabelposition::String = "outside"
-  xaxis_showgrid::Bool = true
-  xaxis_gridcolor::String = "#eee"
-  xaxis_gridwidth::Int = 1
-  xaxis_side::String = "bottom"
-  xaxis_anchor::String = "free"
-  xaxis_position::Float64 = 0.0
-  xaxis_scaleanchor::String = ""
-  xaxis_scaleratio::Int = 1
-  xaxis_constrain::String = "domain"
-  xaxis_constraintoward::String = "center"
-  xaxis_autorange::Union{Bool,String} = true
-  xaxis_rangemode::String = "normal"
-  xaxis_range::Union{Vector{Int},Vector{Float64},Nothing} = nothing
-  xaxis_fixedrange::Bool = false
-  xaxis_type::String = "-"
-  xaxis_autotypenumbers::String = "convert types"
-  xaxis_tickmode::Union{String,Nothing} = nothing
-  xaxis_nticks::Int = 0
-  xaxis_tick0::Union{Float64,Int,String} = 0
-  xaxis_dtick::Union{Float64,Int,String} = 1
-  xaxis_tickvals::Union{Vector{Float64},Vector{Int}} = Int[]
-  xaxis_ticktext::Vector{String} = String[]
-  xaxis_tickformat::String = ""
-
-  yaxis_text::String = "y-axis"
-  yaxis_font::Font = Font()
-  yaxis_automargin::Bool = true
-  yaxis_ticks::String = "inside"
-  yaxis_showline::Bool = false
-  yaxis_zeroline::Bool = true
-  yaxis_linecolor::String = "#444"
-  yaxis_linewidth::Int = 1
-  yaxis_mirror::Union{Bool, String} = false
-  yaxis_ticklabelposition::String = "outside"
-  yaxis_showgrid::Bool = true
-  yaxis_gridcolor::String = "#eee"
-  yaxis_gridwidth::Int = 1
-  yaxis_side::String = "left"
-  yaxis_anchor::String = "free"
-  yaxis_position::Float64 = 0.0
-  yaxis_scaleanchor::String = ""
-  yaxis_scaleratio::Int = 1
-  yaxis_constrain::String = "domain"
-  yaxis_constraintoward::String = "center"
-  yaxis_autorange::Union{Bool,String} = true
-  yaxis_rangemode::String = "normal"
-  yaxis_range::Union{Vector{Int},Vector{Float64},Nothing} = nothing
-  yaxis_fixedrange::Bool = false
-  yaxis_type::String = "-"
-  yaxis_autotypenumbers::String = "convert types"
-  yaxis_tickmode::Union{String,Nothing} = nothing
-  yaxis_nticks::Int = 0
-  yaxis_tick0::Union{Float64,Int,String} = 0
-  yaxis_dtick::Union{Float64,Int,String} = 1
-  yaxis_tickvals::Union{Vector{Float64},Vector{Int}} = Int[]
-  yaxis_ticktext::Vector{String} = String[]
-  yaxis_tickformat::String = ""
+  title::Union{PlotLayoutTitle,Nothing} = nothing
+  xaxis::Union{Vector{PlotLayoutAxis},Nothing} = nothing
+  yaxis::Union{Vector{PlotLayoutAxis},Nothing} = nothing
 
   showlegend::Bool = true
-  legend_bgcolor::Union{String,Nothing} = nothing
-  legend_bordercolor::String = "#444"
-  legend_borderwidth::Int = 0
-  legend_font::Font = Font()
-  legend_orientation::String = LAYOUT_ORIENTATION_VERTICAL
-  legend_traceorder::String = "normal"
-  legend_tracegroupgap::Int = 10
-  legend_itemsizing::String = LAYOUT_ITEMSIZING_TRACE
-  legend_itemwidth::Int = 30
-  legend_itemclick::Union{String,Bool} = LAYOUT_CLICK_TOGGLE
-  legend_itemdoubleclick::Union{String,Bool} = LAYOUT_CLICK_TOGGLEOTHERS
-  legend_x::Union{Int,Float64} = 1.02
-  legend_xanchor::String = LAYOUT_LEFT
-  legend_y::Union{Int,Float64} = 1
-  legend_yanchor::String = LAYOUT_AUTO
-  # TODO: legend_uirevision::Union{Int,String} = ""
-  legend_valign::String = LAYOUT_MIDDLE
-  legend_title_text::String = ""
-  legend_title_font::Font = Font()
-  legend_title_side::String = LAYOUT_LEFT
+  legend::Union{PlotLayoutLegend,Nothing} = nothing
+  annotations::Union{Vector{PlotAnnotation},Nothing} = nothing
+  grid::Union{PlotLayoutGrid,Nothing} = nothing
+
   margin_l::Int = 80
   margin_r::Int = 80
   margin_t::Int = 100
@@ -343,8 +537,9 @@ Base.@kwdef mutable struct PlotLayout
   uniformtext_minsize::Int = 0
   separators::String = ".,"
   paper_bgcolor::String = "#fff"
-  plot_bgcolor::String = "#fff" # TODO: here
+  plot_bgcolor::String = "#fff"
 
+  # TODO: implement the following fields in function Stipple.render(pl::PlotLayout...
   autotypenumbers::String = "convert types"
   # TODO: colorscale settings
   colorway::Vector{String} = ["#1f77b4", "#ff7f0e", "#2ca02c", "#d62728", "#9467bd",
@@ -374,19 +569,7 @@ Base.@kwdef mutable struct PlotLayout
   # TODO: template
   # TODO: meta
   # TODO: computed
-  grid_rows::Union{Int,Nothing} = nothing
-  grid_roworder::String = "top to bottom"
-  grid_columns::Union{Int,Nothing} = nothing
-  # TODO: subplots
-  # TODO: xaxes
-  # TODO: yaxes
-  grid_pattern::String = "coupled"
-  grid_xgap::Float64 = 0.1
-  grid_ygap::Float64 = 0.1
-  grid_domain_x::Vector{Float16} = [0.0, 1.0]
-  grid_domain_y::Vector{Float16} = [0.0, 1.0]
-  grid_xside::String = "bottom plot"
-  grid_yside::String = "left plot"
+
   calendar::String = "gregorian"
   newshape_line_color::String = ""
   newshape_line_width::Int = 4
@@ -424,7 +607,6 @@ Base.@kwdef mutable struct PlotLayout
   extendsunburstcolors::Bool = true
   # TODO: treemapcolorway
   extendtreemapcolors::Bool = true
-  annotations::Union{Vector{PlotAnnotation},Nothing} = nothing
 end
 
 function Base.show(io::IO, l::PlotLayout)
@@ -437,8 +619,112 @@ function Base.show(io::IO, l::PlotLayout)
     end
   end
 
-  print(output)
+  print(io, output)
 end
+
+#===#
+
+Base.@kwdef mutable struct PlotDataLine
+  color::Union{String,Nothing} = nothing
+  width::Union{Int,Nothing} = nothing # 2
+  shape::Union{String,Nothing} = nothing # "linear" | "spline" | "hv" | "vh" | "hvh" | "vhv"
+  smoothing::Union{Float64,String,Nothing} = nothing
+  dash::Union{String,Nothing} = nothing # "solid", "dot", "dash", "longdash", "dashdot", "longdashdot" or "5px,10px,2px,2px"
+  simplify::Union{Bool,Nothing} = nothing
+end
+
+function Base.show(io::IO, pdl::PlotDataLine)
+  output = "Layout Legend: \n"
+  for f in fieldnames(typeof(pdl))
+    prop = getproperty(pdl, f)
+    if prop !== nothing
+      output *= "$f = $prop \n"
+    end
+  end
+
+  print(io, output)
+end
+
+function Base.Dict(pdl::PlotDataLine)
+  trace = Dict{Symbol, Any}()
+
+  optionals!(trace, pdl, [:color, :width, :shape, :smoothing, :dash, :simplify])
+end
+
+function optionals!(d::Dict, pdl::PlotDataLine, opts::Vector{Symbol}) :: Dict
+  for o in opts
+    if getproperty(pdl, o) !== nothing
+      d[o] = getproperty(pdl, o)
+    end
+  end
+
+  d
+end
+
+function Stipple.render(pdl::PlotDataLine, fieldname::Union{Symbol,Nothing} = nothing)
+  Dict(pdl)
+end
+
+#===#
+
+Base.@kwdef mutable struct PlotDataMarker
+  symbol::Union{String,Nothing} = nothing
+  opacity::Union{Float64,Vector{Float64},Nothing} = nothing
+  size::Union{Int,Vector{Int},Nothing} = nothing
+  maxdisplayed::Union{Int,Nothing} = nothing
+  sizeref::Union{Float64,Nothing} = nothing
+  sizemin::Union{Float64,Nothing} = nothing
+  sizemode::Union{String,Nothing} = nothing
+  # TODO: line
+  # TODO: gradient
+  color::Union{String,Vector{Float64},Nothing} = nothing
+  cauto::Union{Bool,Nothing} = nothing
+  cmin::Union{Float64,Nothing} = nothing
+  cmax::Union{Float64,Nothing} = nothing
+  cmid::Union{Float64,Nothing} = nothing
+  colorscale::Union{Matrix,String,Nothing} = nothing
+  autocolorscale::Union{Bool,Nothing} = nothing
+  reversescale::Union{Bool,Nothing} = nothing
+  showscale::Union{Bool,Nothing} = nothing
+  # TODO: colorbar
+  coloraxis::Union{String,Nothing} = nothing
+end
+
+function Base.show(io::IO, pdm::PlotDataMarker)
+  output = "Layout Legend: \n"
+  for f in fieldnames(typeof(pdm))
+    prop = getproperty(pdm, f)
+    if prop !== nothing
+      output *= "$f = $prop \n"
+    end
+  end
+
+  print(io, output)
+end
+
+function Base.Dict(pdm::PlotDataMarker)
+  trace = Dict{Symbol, Any}()
+
+  optionals!(trace, pdm, [:symbol, :opacity, :size, :maxdisplayed, :sizeref, :sizemin,
+      :sizemode, :color, :cauto, :cmin, :cmax, :cmid, :colorscale, :autocolorscale,
+      :reversescale, :showscale, :coloraxis])
+end
+
+function optionals!(d::Dict, pdm::PlotDataMarker, opts::Vector{Symbol}) :: Dict
+  for o in opts
+    if getproperty(pdm, o) !== nothing
+      d[o] = getproperty(pdm, o)
+    end
+  end
+
+  d
+end
+
+function Stipple.render(pdm::PlotDataMarker, fieldname::Union{Symbol,Nothing} = nothing)
+  Dict(pdm)
+end
+
+#===#
 
 Base.@kwdef mutable struct PlotData
   plot::String = PLOT_TYPE_SCATTER
@@ -528,10 +814,10 @@ Base.@kwdef mutable struct PlotData
   legendgroup::Union{String,Nothing} = nothing
   lighting::Union{Dict,Nothing} = nothing
   lightposition::Union{Dict,Nothing} = nothing
-  line::Union{Dict,Nothing} = nothing
+  line::Union{Dict,PlotDataLine,Nothing} = nothing
   low::Union{Vector,Nothing} = nothing
   lowerfence::Union{Vector,Nothing} = nothing
-  marker::Union{Dict,Nothing} = nothing
+  marker::Union{Dict,PlotDataMarker,Nothing} = nothing
   maxdisplayed::Union{Int,Nothing} = nothing
   mean::Union{Vector,Nothing} = nothing
   measure::Union{Vector,Nothing} = nothing
@@ -640,18 +926,82 @@ end
 
 const Trace = PlotData
 
+# =============
+
+# Reference: https://github.com/plotly/plotly.js/blob/master/src/plot_api/plot_config.js?package=plotly&version=3.6.0
+
+Base.@kwdef mutable struct PlotConfig
+  responsive::Union{Bool,Nothing} = nothing # default: false
+  editable::Union{Bool,Nothing} = nothing # default: false
+  scrollzoom::Union{Bool,String,Nothing} = nothing  # ['cartesian', 'gl3d', 'geo', 'mapbox'], [true, false]; default: gl3d+geo+mapbox'
+  staticplot::Union{Bool,Nothing} = nothing # default: false
+  displaymodebar::Union{Bool,String,Nothing} = nothing # ['hover', true, false], default: "hover"
+  displaylogo::Union{Bool,Nothing} = nothing # default: true
+  toimage_format::Union{String,Nothing} = nothing # one of ["png", "svg", "jpeg", "webp"]
+  toimage_filename::Union{String,Nothing} = nothing # "newplot"
+  toimage_height::Union{Int,Nothing} = nothing # 500
+  toimage_width::Union{Int,Nothing} = nothing # 700
+  toimage_scale::Union{Int,Float64,Nothing} = nothing # 1
+end
+
+function Base.show(io::IO, pc::PlotConfig)
+  output = "configuration: \n"
+  for f in fieldnames(typeof(pc))
+    prop = getproperty(pc, f)
+    if prop !== nothing
+      output *= "$f = $prop \n"
+    end
+  end
+
+  print(io, output)
+end
+
+function Base.Dict(pc::PlotConfig)
+  trace = Dict{Symbol, Any}()
+
+  if (pc.toimage_format in ["png", "svg", "jpeg", "webp"])
+    d = Dict{Symbol, Any}(:format => pc.toimage_format)
+    d[:filename] = (pc.toimage_filename === nothing) ? "newplot" : pc.toimage_filename
+    d[:height] = (pc.toimage_height === nothing) ? 500 : pc.toimage_height
+    d[:width] = (pc.toimage_width === nothing) ? 700 : pc.toimage_width
+    d[:scale] = (pc.toimage_scale === nothing) ? 1 : pc.toimage_scale
+    trace[:toImageButtonOptions] = d
+  end
+
+  optionals!(trace, pc, [:responsive, :editable, :scrollzoom, :staticplot, :displaymodebar, :displaylogo])
+end
+
+function optionals!(d::Dict, pc::PlotConfig, opts::Vector{Symbol}) :: Dict
+  for o in opts
+    if getproperty(pc, o) !== nothing
+      d[o] = getproperty(pc, o)
+    end
+  end
+
+  d
+end
+
+function Stipple.render(pc::PlotConfig, fieldname::Union{Symbol,Nothing} = nothing)
+  Dict(pc)
+end
+
+# =============
+
 function plot(fieldname::Symbol;
               layout::Union{Symbol,PlotLayout} = PlotLayout(),
+              config::Union{Symbol,PlotConfig} = PlotConfig(),
               wrap::Function = DEFAULT_WRAPPER,
               args...) :: String
 
-  k = (Symbol(":data"), Symbol(":layout"))
-  v = Any["$fieldname", layout]
+  k = (Symbol(":data"), Symbol(":layout"), Symbol(":config"))
+  v = Any["$fieldname", layout, config]
 
   wrap() do
     plotly(; args..., NamedTuple{k}(v)...)
   end
 end
+
+# =============
 
 function Base.show(io::IO, pd::PlotData)
   output = "$(pd.plot): \n"
@@ -662,9 +1012,8 @@ function Base.show(io::IO, pd::PlotData)
     end
   end
 
-  print(output)
+  print(io, output)
 end
-
 
 #===#
 
@@ -697,6 +1046,9 @@ function Base.Dict(pd::PlotData)
     )
   end
 
+  (pd.line !== nothing) && (trace[:line] = Dict(pd.line))
+  (pd.marker !== nothing) && (trace[:marker] = Dict(pd.marker))
+
   optionals!(trace, pd, [:align, :alignmentgroup, :alphahull, :anchor, :aspectratio, :autobinx, :autobiny,
                         :autocolorscale, :autocontour, :automargin,
                         :bandwidth, :base, :baseratio, :bingroup, :box, :boxmean, :boxpoints,
@@ -711,8 +1063,8 @@ function Base.Dict(pd::PlotData)
                         :hole, :hovertext, :hoverinfo, :hovertemplate, :hoverlabel, :hoveron, :hoverongaps,
                         :i, :intensity, :intensitymode, :ids, :increasing, :insidetextanchor, :insidetextorientation, :isomax, :isomin,
                         :j, :jitter, :k,
-                        :labels, :label0, :legendgroup, :lighting, :lightposition, :line, :low, :lowerfence,
-                        :marker, :maxdisplayed, :meanline, :measure, :median, :meta,
+                        :labels, :label0, :legendgroup, :lighting, :lightposition, :low, :lowerfence,
+                        :maxdisplayed, :meanline, :measure, :median, :meta,
                         :mode,
                         :name, :nbinsx, :nbinsy, :ncontours, :notched, :notchwidth, :notchspan, :number,
                         :offset, :offsetgroup, :opacity, :opacityscale, :open, :orientation,
@@ -751,135 +1103,11 @@ function Stipple.render(pdv::Vector{PlotData}, fieldname::Union{Symbol,Nothing} 
   [Dict(pd) for pd in pdv]
 end
 
-
-
 #===#
-
 
 function Stipple.render(pl::PlotLayout, fieldname::Union{Symbol,Nothing} = nothing)
   layout = Dict(
-    :title => Dict(
-      :text => pl.title_text,
-      :font => Dict(
-        :family => pl.title_font.family,
-        :size => pl.title_font.size,
-        :color => pl.title_font.color
-      ),
-      :xref => pl.title_xref,
-      :yref => pl.title_yref,
-      :x => pl.title_x,
-      :y => pl.title_y,
-      :xanchor => pl.title_xanchor,
-      :yanchor => pl.title_yanchor,
-      :pad => Dict(
-        :t => pl.title_pad_t,
-        :r => pl.title_pad_r,
-        :b => pl.title_pad_b,
-        :l => pl.title_pad_l
-      )
-    ),
-
-    :xaxis => Dict(
-      :title => Dict(
-        :text => pl.xaxis_text,
-        :font => Dict(
-          :family => pl.xaxis_font.family,
-          :size => pl.xaxis_font.size,
-          :color => pl.xaxis_font.color
-        )
-      ),
-      :automargin => pl.xaxis_automargin,
-      :ticks => pl.xaxis_ticks,
-      :showline => pl.xaxis_showline,
-      :zeroline => pl.xaxis_zeroline,
-      :linecolor => pl.xaxis_linecolor,
-      :linewidth => pl.xaxis_linewidth,
-      :mirror => pl.xaxis_mirror,
-      :ticklabelposition => pl.xaxis_ticklabelposition,
-      :showgrid => pl.xaxis_showgrid,
-      :gridcolor => pl.xaxis_gridcolor,
-      :gridwidth => pl.xaxis_gridwidth,
-      :anchor => pl.xaxis_anchor,
-      :position => pl.xaxis_position,
-      :side => pl.xaxis_side,
-      :scaleanchor => pl.xaxis_scaleanchor,
-      :scaleratio => pl.xaxis_scaleratio,
-      :constrain => pl.xaxis_constrain,
-      :constraintoward => pl.xaxis_constraintoward,
-      :autorange => pl.xaxis_autorange,
-      :rangemode => pl.xaxis_rangemode,
-      :fixedrange => pl.xaxis_fixedrange,
-      :type => pl.xaxis_type,
-      :autotypenumbers => pl.xaxis_autotypenumbers,
-      :tickformat => pl.xaxis_tickformat
-    ),
-
-    :yaxis => Dict(
-      :title => Dict(
-        :text => pl.yaxis_text,
-        :font => Dict(
-          :family => pl.yaxis_font.family,
-          :size => pl.yaxis_font.size,
-          :color => pl.yaxis_font.color
-        )
-      ),
-      :automargin => pl.yaxis_automargin,
-      :ticks => pl.yaxis_ticks,
-      :showline => pl.yaxis_showline,
-      :zeroline => pl.yaxis_zeroline,
-      :linecolor => pl.yaxis_linecolor,
-      :linewidth => pl.yaxis_linewidth,
-      :mirror => pl.yaxis_mirror,
-      :ticklabelposition => pl.yaxis_ticklabelposition,
-      :showgrid => pl.yaxis_showgrid,
-      :gridcolor => pl.yaxis_gridcolor,
-      :gridwidth => pl.yaxis_gridwidth,
-      :anchor => pl.yaxis_anchor,
-      :position => pl.yaxis_position,
-      :side => pl.yaxis_side,
-      :scaleanchor => pl.yaxis_scaleanchor,
-      :scaleratio => pl.yaxis_scaleratio,
-      :scaleratio => pl.yaxis_scaleratio,
-      :constrain => pl.yaxis_constrain,
-      :constraintoward => pl.yaxis_constraintoward,
-      :autorange => pl.yaxis_autorange,
-      :rangemode => pl.yaxis_rangemode,
-      :fixedrange => pl.yaxis_fixedrange,
-      :type => pl.yaxis_type,
-      :autotypenumbers => pl.yaxis_autotypenumbers,
-      :tickformat => pl.yaxis_tickformat
-    ),
-
     :showlegend => pl.showlegend,
-    :legend => Dict(
-      :bordercolor => pl.legend_bordercolor,
-      :font => Dict(
-        :family => pl.legend_font.family,
-        :size => pl.legend_font.size,
-        :color => pl.legend_font.color
-      ),
-      :orientation => pl.legend_orientation,
-      :traceorder => pl.legend_traceorder,
-      :tracegroupgrap => pl.legend_tracegroupgap,
-      :itemsizing => pl.legend_itemsizing,
-      :itemwidth => pl.legend_itemwidth,
-      :itemclick => pl.legend_itemclick,
-      :itemdoubleclick => pl.legend_itemdoubleclick,
-      :x => pl.legend_x,
-      :xanchor => pl.legend_xanchor,
-      :y => pl.legend_y,
-      :yanchor => pl.legend_yanchor,
-      :valign => pl.legend_valign,
-      :title => Dict(
-        :text => pl.legend_title_text,
-        :font => Dict(
-          :family => pl.legend_title_font.family,
-          :size => pl.legend_title_font.size,
-          :color => pl.legend_title_font.color
-        ),
-        :side => pl.legend_title_side,
-      )
-    ),
     :margin => Dict(
       :l => pl.margin_l,
       :r => pl.margin_r,
@@ -889,8 +1117,6 @@ function Stipple.render(pl::PlotLayout, fieldname::Union{Symbol,Nothing} = nothi
       :autoexpand => pl.margin_autoexpand
     ),
     :autosize => pl.autosize,
-    # :width => pl.width,
-    # :height => pl.height,
     :font => Dict(
       :family => pl.font.family,
       :size => pl.font.size,
@@ -905,46 +1131,28 @@ function Stipple.render(pl::PlotLayout, fieldname::Union{Symbol,Nothing} = nothi
     :plot_bgcolor => pl.plot_bgcolor
   )
 
-  (pl.legend_bgcolor !== nothing) && (layout[:legend_bgcolor] = pl.legend_bgcolor)
   (pl.width !== nothing) && (layout[:width] = pl.width)
   (pl.height !== nothing) && (layout[:height] = pl.height)
+  (pl.title !== nothing) && (layout[:title] = Dict(pl.title))
+  (pl.legend !== nothing) && (layout[:legend] = Dict(pl.legend))
+  (pl.annotations !== nothing) && (layout[:annotations] = Dict.(pl.annotations))
+  (pl.grid !== nothing) && (layout[:grid] = Dict(pl.grid))
 
-  (pl.xaxis_range !== nothing) && (layout[:xaxis][:range] = pl.xaxis_range)
-  if pl.xaxis_tickmode == "linear"
-    layout[:xaxis][:tickmode] = pl.xaxis_tickmode
-    layout[:xaxis][:tick0] = pl.xaxis_tick0
-    layout[:xaxis][:dtick] = pl.xaxis_dtick
-  elseif pl.xaxis_tickmode == "array"
-    layout[:xaxis][:tickmode] = pl.xaxis_tickmode
-    layout[:xaxis][:tickvals] = pl.xaxis_tickvals
-    layout[:xaxis][:ticktext] = pl.xaxis_ticktext
-  elseif pl.xaxis_tickmode == "auto"
-    layout[:xaxis][:tickmode] = pl.xaxis_tickmode
-    layout[:xaxis][:nticks] = pl.xaxis_nticks
+  if pl.xaxis !== nothing
+    for d in Dict.(pl.xaxis)
+      merge!(layout, d)
+    end
   end
 
-  (pl.yaxis_range !== nothing) && (layout[:yaxis][:range] = pl.yaxis_range)
-  if pl.yaxis_tickmode == "linear"
-    layout[:yaxis][:tickmode] = pl.yaxis_tickmode
-    layout[:yaxis][:tick0] = pl.yaxis_tick0
-    layout[:yaxis][:dtick] = pl.yaxis_dtick
-  elseif pl.yaxis_tickmode == "array"
-    layout[:yaxis][:tickmode] = pl.yaxis_tickmode
-    layout[:yaxis][:tickvals] = pl.yaxis_tickvals
-    layout[:yaxis][:ticktext] = pl.yaxis_ticktext
-  elseif pl.yaxis_tickmode == "auto"
-    layout[:yaxis][:tickmode] = pl.yaxis_tickmode
-    layout[:yaxis][:nticks] = pl.yaxis_nticks
-  end
-
-  if pl.annotations !== nothing
-    layout[:annotations] = Dict.(pl.annotations)
+  if pl.yaxis !== nothing
+    for d in Dict.(pl.yaxis)
+      merge!(layout, d)
+    end
   end
 
   layout
 end
 
 # #===#
-
 
 end

--- a/src/Charts.jl
+++ b/src/Charts.jl
@@ -161,6 +161,19 @@ Base.@kwdef mutable struct PlotLayout
   xaxis_scaleratio::Int = 1
   xaxis_constrain::String = "domain"
   xaxis_constraintoward::String = "center"
+  xaxis_autorange::Union{Bool,String} = true
+  xaxis_rangemode::String = "normal"
+  xaxis_range::Union{Vector{Int},Vector{Float64},Nothing} = nothing
+  xaxis_fixedrange::Bool = false
+  xaxis_type::String = "-"
+  xaxis_autotypenumbers::String = "convert types"
+  xaxis_tickmode::Union{String,Nothing} = nothing
+  xaxis_nticks::Int = 0
+  xaxis_tick0::Union{Float64,Int,String} = 0
+  xaxis_dtick::Union{Float64,Int,String} = 1
+  xaxis_tickvals::Union{Vector{Float64},Vector{Int}} = Int[]
+  xaxis_ticktext::Vector{String} = String[]
+  xaxis_tickformat::String = ""
 
   yaxis_text::String = "y-axis"
   yaxis_font::Font = Font()
@@ -182,6 +195,19 @@ Base.@kwdef mutable struct PlotLayout
   yaxis_scaleratio::Int = 1
   yaxis_constrain::String = "domain"
   yaxis_constraintoward::String = "center"
+  yaxis_autorange::Union{Bool,String} = true
+  yaxis_rangemode::String = "normal"
+  yaxis_range::Union{Vector{Int},Vector{Float64},Nothing} = nothing
+  yaxis_fixedrange::Bool = false
+  yaxis_type::String = "-"
+  yaxis_autotypenumbers::String = "convert types"
+  yaxis_tickmode::Union{String,Nothing} = nothing
+  yaxis_nticks::Int = 0
+  yaxis_tick0::Union{Float64,Int,String} = 0
+  yaxis_dtick::Union{Float64,Int,String} = 1
+  yaxis_tickvals::Union{Vector{Float64},Vector{Int}} = Int[]
+  yaxis_ticktext::Vector{String} = String[]
+  yaxis_tickformat::String = ""
 
   showlegend::Bool = true
   legend_bgcolor::Union{String,Nothing} = nothing
@@ -211,8 +237,8 @@ Base.@kwdef mutable struct PlotLayout
   margin_pad::Int = 0
   margin_autoexpand::Bool = true
   autosize::Bool = true
-  width::Int = 700
-  height::Int = 450
+  width::Union{Int,Nothing} = nothing #700
+  height::Union{Int,Nothing} = nothing #450
   font::Font = Font()
   uniformtext_mode::Union{String,Bool} = false
   uniformtext_minsize::Int = 0
@@ -539,6 +565,7 @@ function Base.show(io::IO, pd::PlotData)
   print(output)
 end
 
+
 #===#
 
 function Base.Dict(pd::PlotData)
@@ -673,7 +700,13 @@ function Stipple.render(pl::PlotLayout, fieldname::Union{Symbol,Nothing} = nothi
       :scaleanchor => pl.xaxis_scaleanchor,
       :scaleratio => pl.xaxis_scaleratio,
       :constrain => pl.xaxis_constrain,
-      :constraintoward => pl.xaxis_constraintoward
+      :constraintoward => pl.xaxis_constraintoward,
+      :autorange => pl.xaxis_autorange,
+      :rangemode => pl.xaxis_rangemode,
+      :fixedrange => pl.xaxis_fixedrange,
+      :type => pl.xaxis_type,
+      :autotypenumbers => pl.xaxis_autotypenumbers,
+      :tickformat => pl.xaxis_tickformat
     ),
 
     :yaxis => Dict(
@@ -703,7 +736,13 @@ function Stipple.render(pl::PlotLayout, fieldname::Union{Symbol,Nothing} = nothi
       :scaleratio => pl.yaxis_scaleratio,
       :scaleratio => pl.yaxis_scaleratio,
       :constrain => pl.yaxis_constrain,
-      :constraintoward => pl.yaxis_constraintoward
+      :constraintoward => pl.yaxis_constraintoward,
+      :autorange => pl.yaxis_autorange,
+      :rangemode => pl.yaxis_rangemode,
+      :fixedrange => pl.yaxis_fixedrange,
+      :type => pl.yaxis_type,
+      :autotypenumbers => pl.yaxis_autotypenumbers,
+      :tickformat => pl.yaxis_tickformat
     ),
 
     :showlegend => pl.showlegend,
@@ -745,8 +784,8 @@ function Stipple.render(pl::PlotLayout, fieldname::Union{Symbol,Nothing} = nothi
       :autoexpand => pl.margin_autoexpand
     ),
     :autosize => pl.autosize,
-    :width => pl.width,
-    :height => pl.height,
+    # :width => pl.width,
+    # :height => pl.height,
     :font => Dict(
       :family => pl.font.family,
       :size => pl.font.size,
@@ -761,7 +800,37 @@ function Stipple.render(pl::PlotLayout, fieldname::Union{Symbol,Nothing} = nothi
     :plot_bgcolor => pl.plot_bgcolor
   )
 
-  pl.legend_bgcolor !== nothing && (layout[:legend_bgcolor] = pl.legend_bgcolor)
+  (pl.legend_bgcolor !== nothing) && (layout[:legend_bgcolor] = pl.legend_bgcolor)
+  (pl.width !== nothing) && (layout[:width] = pl.width)
+  (pl.height !== nothing) && (layout[:height] = pl.height)
+
+  (pl.xaxis_range !== nothing) && (layout[:xaxis][:range] = pl.xaxis_range)
+  if pl.xaxis_tickmode == "linear"
+    layout[:xaxis][:tickmode] = pl.xaxis_tickmode
+    layout[:xaxis][:tick0] = pl.xaxis_tick0
+    layout[:xaxis][:dtick] = pl.xaxis_dtick
+  elseif pl.xaxis_tickmode == "array"
+    layout[:xaxis][:tickmode] = pl.xaxis_tickmode
+    layout[:xaxis][:tickvals] = pl.xaxis_tickvals
+    layout[:xaxis][:ticktext] = pl.xaxis_ticktext
+  elseif pl.xaxis_tickmode == "auto"
+    layout[:xaxis][:tickmode] = pl.xaxis_tickmode
+    layout[:xaxis][:nticks] = pl.xaxis_nticks
+  end
+
+  (pl.yaxis_range !== nothing) && (layout[:yaxis][:range] = pl.yaxis_range)
+  if pl.yaxis_tickmode == "linear"
+    layout[:yaxis][:tickmode] = pl.yaxis_tickmode
+    layout[:yaxis][:tick0] = pl.yaxis_tick0
+    layout[:yaxis][:dtick] = pl.yaxis_dtick
+  elseif pl.yaxis_tickmode == "array"
+    layout[:yaxis][:tickmode] = pl.yaxis_tickmode
+    layout[:yaxis][:tickvals] = pl.yaxis_tickvals
+    layout[:yaxis][:ticktext] = pl.yaxis_ticktext
+  elseif pl.yaxis_tickmode == "auto"
+    layout[:yaxis][:tickmode] = pl.yaxis_tickmode
+    layout[:yaxis][:nticks] = pl.yaxis_nticks
+  end
 
   layout
 end

--- a/src/Charts.jl
+++ b/src/Charts.jl
@@ -5,7 +5,7 @@ import Genie.Renderer.Html: HTMLString, normal_element
 
 using Stipple
 
-export PlotLayout, PlotData, Trace, plot, ErrorBar, Font, ColorBar
+export PlotLayout, PlotData, PlotAnnotation, Trace, plot, ErrorBar, Font, ColorBar
 
 const DEFAULT_WRAPPER = Genie.Renderer.Html.template
 
@@ -126,6 +126,105 @@ end
 Base.:(==)(x::Font, y::Font) = x.family == y.family && x.size == y.size && x.color == y.color
 
 Base.hash(f::Font) = hash("$(f.family)$(f.size)$(f.color)")
+
+#===#
+
+Base.@kwdef mutable struct PlotAnnotation
+  visible::Union{Bool,Nothing} = nothing
+  text::Union{String,Nothing} = nothing
+  textangle::Union{Float64,Int,Nothing} = nothing
+  font::Union{Font,Nothing} = nothing
+  width::Union{Float64,Int,Nothing} = nothing
+  height::Union{Float64,Int,Nothing} = nothing
+  opacity::Union{Float64,Nothing} = nothing
+  align::Union{String,Nothing} = nothing
+  valign::Union{String,Nothing} = nothing
+  bgcolor::Union{String,Nothing} = nothing
+  bordercolor::Union{String,Nothing} = nothing
+  borderpad::Union{Int,Nothing} = nothing
+  borderwidth::Union{Int,Nothing} = nothing
+  showarrow::Union{Bool,Nothing} = nothing
+  arrowcolor::Union{String,Nothing} = nothing
+  arrowhead::Union{Int,Nothing} = nothing
+  startarrowhead::Union{Int,Nothing} = nothing
+  arrowside::Union{String,Nothing} = nothing
+  arrowsize::Union{Float64,Nothing} = nothing
+  startarrowsize::Union{Float64,Nothing} = nothing
+  arrowwidth::Union{Float64,Nothing} = nothing
+  standoff::Union{Int,Nothing} = nothing
+  startstandoff::Union{Int,Nothing} = nothing
+  ax::Union{String,Int,Float64,Nothing} = nothing
+  ay::Union{String,Int,Float64,Nothing} = nothing
+  axref::Union{String,Nothing} = nothing
+  ayref::Union{String,Nothing} = nothing
+  xref::Union{String,Int,Float64,Nothing} = nothing
+  x::Union{String,Int,Float64,Nothing} = nothing
+  xanchor::Union{String,Nothing} = nothing
+  xshift::Union{Int,Float64,Nothing} = nothing
+  yref::Union{String,Int,Float64,Nothing} = nothing
+  y::Union{String,Int,Float64,Nothing} = nothing
+  yanchor::Union{String,Nothing} = nothing
+  yshift::Union{Int,Float64,Nothing} = nothing
+  # TODO: clicktoshow
+  # TODO: xclick
+  # TODO: yclick
+  hoverlabel::Union{Dict,Nothing} = nothing
+  captureevents::Union{Bool,Nothing} = nothing
+  name::Union{String,Nothing} = nothing
+  templateitemname::Union{String,Nothing} = nothing
+end
+
+function Base.show(io::IO, an::PlotAnnotation)
+  output = "Annotation: \n"
+  for f in fieldnames(typeof(an))
+    prop = getproperty(an, f)
+    if prop !== nothing
+      output *= "$f = $prop \n"
+    end
+  end
+
+  print(output)
+end
+
+function Base.Dict(an::PlotAnnotation)
+  trace = Dict{Symbol,Any}()
+
+  if an.font !== nothing
+    trace[:font] = Dict(
+      :family => an.font.family,
+      :size => an.font.size,
+      :color => an.font.color
+    )
+  end
+
+  if an.hoverlabel !== nothing
+    trace[:hoverlabel] = an.hoverlabel
+  end
+
+  optionals!(trace, an, [:visible, :text, :textangle, :width, :height, :opacity,
+          :align, :valign, :bgcolor, :bordercolor, :borderpad, :borderwidth, :showarrow,
+          :arrowcolor, :arrowhead, :startarrowhead, :arrowside, :arrowsize, :startarrowsize,
+          :arrowwidth, :standoff, :startstandoff, :ax, :ay, :axref, :ayref, :xref, :x,
+          :xanchor, :xshift, :yref, :y, :yanchor, :yshift, :captureevents, :name, :templateitemname])
+
+end
+
+function optionals!(d::Dict, an::PlotAnnotation, opts::Vector{Symbol}) :: Dict
+  for o in opts
+    if getproperty(an, o) !== nothing
+      d[o] = getproperty(an, o)
+    end
+  end
+
+  d
+end
+
+function Stipple.render(anv::Vector{PlotAnnotation}, fieldname::Union{Symbol,Nothing} = nothing)
+  [Dict(an) for an in anv]
+end
+
+
+#===#
 
 Base.@kwdef mutable struct PlotLayout
   title_text::String = ""
@@ -325,6 +424,7 @@ Base.@kwdef mutable struct PlotLayout
   extendsunburstcolors::Bool = true
   # TODO: treemapcolorway
   extendtreemapcolors::Bool = true
+  annotations::Union{Vector{PlotAnnotation},Nothing} = nothing
 end
 
 function Base.show(io::IO, l::PlotLayout)
@@ -651,6 +751,11 @@ function Stipple.render(pdv::Vector{PlotData}, fieldname::Union{Symbol,Nothing} 
   [Dict(pd) for pd in pdv]
 end
 
+
+
+#===#
+
+
 function Stipple.render(pl::PlotLayout, fieldname::Union{Symbol,Nothing} = nothing)
   layout = Dict(
     :title => Dict(
@@ -830,6 +935,10 @@ function Stipple.render(pl::PlotLayout, fieldname::Union{Symbol,Nothing} = nothi
   elseif pl.yaxis_tickmode == "auto"
     layout[:yaxis][:tickmode] = pl.yaxis_tickmode
     layout[:yaxis][:nticks] = pl.yaxis_nticks
+  end
+
+  if pl.annotations !== nothing
+    layout[:annotations] = Dict.(pl.annotations)
   end
 
   layout


### PR DESCRIPTION
@essenciary, @hhaensel:

With this PR, I propose additions and changes for StipplePlotly. Note that some changes break backward compatibilty.

Here are the most significant changes and additions:

- In general, I propose to follow the original design pattern as laid out for PlotData: a mutable structure, and show, Dict and Stipple.render functions with optionals! as a supporting function. I followed the Plotly reference as much as possible, so names of options differ from Julia Plots.
- Plotly JS comes with a comprehensive set of defaults for graphs. So, it is not necessary to change and send from back-end to front-end all optional parameters/settings. This was how it was implemented for PlotData. I propose to apply it for PlotLayout as well. 
-  Plotly JS has several (sub)elements, e.g. axis, colorbar, legend, line marker, title etc. In this PR I promoted such elements to structures in Julia. Previous PR implemented this for plot annotations as demonstrated in example heatmap2.jl in the docs directory. I updated all examples to reflect the changes. 
- It is worthwhile for some use cases to change Plotly configuration options, e.g. change download filetype. This is the Config structure in Julia Charts.jl. However, this needs a change to vueplot.js by adding a third argument to javascript function newPlot. By any measure I am not familiar with javascript, so help is welcome here.
- In the docs are now examples for subplots and bar-type plots. I updated all other examples.

On the downside, creating code in Julia can become verbose for simple plots. I think one can create shortcuts or implement "styles" like PlotlyBase does.

Finally, Plotly JS has so many options that I still haven't implemented. So far, I've implemented plots that serve my use cases. If some graphs are missing, I am happy to create examples for the docs. Interaction with Vue (e.g. scaling of graph size) I have not explored yet.
 