### PR TITLE
Support PlotlyBase

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.10.2"
 
 [deps]
 Genie = "c43c736e-a2d1-11e8-161f-af95117fbd1e"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Stipple = "4acbeb90-81a0-11ea-1966-bdaff8155998"
 
 [compat]

--- a/src/Charts.jl
+++ b/src/Charts.jl
@@ -1344,6 +1344,8 @@ function Stipple.render(pl::Vector{PlotLayout}, fieldname::Union{Symbol,Nothing}
   Dict.(pl)
 end
 
+Base.print(io::IO, a::Union{PlotLayout, PlotConfig}) = print(io, Stipple.json(a))
+
 # #===#
 
 end

--- a/src/StipplePlotly.jl
+++ b/src/StipplePlotly.jl
@@ -1,6 +1,7 @@
 module StipplePlotly
 
 using Genie, Stipple, Stipple.Reexport
+using Requires
 
 #===#
 
@@ -59,6 +60,29 @@ include("Charts.jl")
 
 function __init__()
   Stipple.DEPS[@__MODULE__] = deps
+
+  @require PlotlyBase = "a03496cd-edff-5a9b-9e67-9cda94a718b5" begin
+    function Charts.plot(fieldname::Union{Symbol,AbstractString};
+      layout::Union{Symbol,PlotLayout,AbstractString,PlotlyBase.Layout} = PlotLayout(),
+      config::Union{Symbol,PlotConfig,AbstractString,PlotlyBase.PlotConfig} = StipplePlotly.PlotConfig(),
+      args...) :: String
+
+      k = (Symbol(":data"), Symbol(":layout"), Symbol(":config"))
+      v = Any["$fieldname", layout, config]
+
+      Charts.plotly(; args..., NamedTuple{k}(v)...)
+    end
+    
+    function plotly(p::Symbol; layout = "p.layout", config = "p.config", kwargs...)
+      plot("p.data"; layout, config, kwargs...)
+    end
+
+    Base.print(io::IO, a::Union{PlotlyBase.PlotConfig}) = print(io, Stipple.json(a))
+    StructTypes.StructType(::Type{<:PlotlyBase.HasFields}) = JSON3.RawType()
+    StructTypes.StructType(::Type{PlotlyBase.PlotConfig}) = JSON3.RawType()
+
+    JSON3.rawbytes(x::Union{PlotlyBase.HasFields,PlotlyBase.PlotConfig}) = codeunits(PlotlyBase.JSON.json(x))
+  end
 end
 
 end # module


### PR DESCRIPTION
Support PlotlyBase by definition by two enhancements
- enhance the accepted types for the kwargs `layout`and `config` in `plot()`
- define `plotly(p::Symbol)`, which integrates a PlotlyBase.Plot that is part of the model

That way we make it possible to write
```julia
using Stipple, StipplePlotly
using PlotlyBase

@reactive! mutable struct Example <: ReactiveModel
    plot::R{Plot} = Plot()
end

function ui(model::Example)
    page(model, class = "container", [
        # possibility 1: layout and config are taken from the Plot object
        plotly(:plot)
        # possibility 2: layout and config are defined separately and can be either from StipplePlotly or PlotlyBase
        plot("plot.data", layout = Layout(), config = StipplePlotly.PlotConfig())
    ])
end

model = init(Example, debounce=0)
route("/") do
    model |> ui |> html
end

up(8800)

for i in 1:30
    model.plot[] = Plot(rand(100,2))
    sleep(0.1)
end
```

Note that I included fixes for PlotlyBase that are [currently pending ](https://github.com/sglyon/PlotlyBase.jl/pull/95) or are not yet published in the latest version. That way I make sure that this PR already works with latest published version of PlotlyBase.