### PR TITLE
Allow for vectors as base

### DIFF
--- a/src/Charts.jl
+++ b/src/Charts.jl
@@ -381,7 +381,7 @@ Base.@kwdef mutable struct PlotData
   autocontour::Union{Bool,Nothing} = nothing
   automargin::Union{Bool,Nothing} = nothing
   bandwidth::Union{Float64,Int,Nothing} = nothing
-  base::Union{Float64,Int,String,Nothing} = nothing
+  base::Union{Vector,Float64,Int,String,Nothing} = nothing
   baseratio::Union{Float64,Int,Nothing} = nothing
   bingroup::Union{String,Nothing} = nothing
   box::Union{Dict,Nothing} = nothing


### PR DESCRIPTION
This should allow for floating bar charts.

```julia
tasks = PlotData(
    x = [1, 4, 3], # duration
    base = [4, 1, 2], # start
    y = ["Task 1", "Task 2", "Task 3"],
    plot = StipplePlotly.Charts.PLOT_TYPE_BAR,
    name = "Tasks",
    orientation="h",
)
```