### PR TITLE
fix xaxis/yaxis rendering, add keyword axes in PlotLayout

### DIFF
--- a/src/Layouts.jl
+++ b/src/Layouts.jl
@@ -646,7 +646,7 @@ function Base.show(io::IO, la::PlotLayoutAxis)
   print(io, output)
 end
 
-function Base.Dict(la::PlotLayoutAxis)
+function Base.Dict(la::PlotLayoutAxis, xy::String = "")
   trace = Dict{Symbol,Any}()
 
   if la.title_text !== nothing
@@ -666,8 +666,7 @@ function Base.Dict(la::PlotLayoutAxis)
     :tickcolor, :tickfont, :tickformat, :ticklabelmode, :ticklabelposition, :ticklen, :tickmode,
     :tickprefix, :ticks, :tickson, :ticksuffix, :ticktext, :tickvals, :tickwidth, :title, :type,
     :visible, :zeroline, :zerolinecolor, :zerolinewidth])
-
-  k = Symbol(la.xy * "axis" * ((la.index > 1) ? "$(la.index)" : ""))
+  k = Symbol(isempty(xy) ? la.xy : xy, "axis", la.index > 1 ? "$(la.index)" : "")
   Dict(k => d)
 end
 
@@ -1233,15 +1232,13 @@ function Base.Dict(pl::PlotLayout, fieldname::Union{Symbol,Nothing} = nothing)
 
   if pl.xaxis !== nothing
     for x in pl.xaxis
-      x.xy = "x"
-      merge!(layout, Dict(x))
+      merge!(layout, Dict(x, "x"))
     end
   end
 
   if pl.yaxis !== nothing
     for y in pl.yaxis
-      y.xy = "y"
-      merge!(layout, Dict(y))
+      merge!(layout, Dict(y, "y"))
     end
   end
 

--- a/src/Layouts.jl
+++ b/src/Layouts.jl
@@ -1089,6 +1089,7 @@ Base.@kwdef mutable struct PlotLayout
   title::Union{PlotLayoutTitle,Nothing} = nothing
   xaxis::Union{Vector{PlotLayoutAxis},Nothing} = nothing
   yaxis::Union{Vector{PlotLayoutAxis},Nothing} = nothing
+  axes::Union{Vector{PlotLayoutAxis},Nothing} = nothing
 
   showlegend::Union{Bool,Nothing} = nothing # true
   legend::Union{PlotLayoutLegend,Nothing} = nothing
@@ -1231,13 +1232,21 @@ function Base.Dict(pl::PlotLayout, fieldname::Union{Symbol,Nothing} = nothing)
 
 
   if pl.xaxis !== nothing
-    for d in Dict.(pl.xaxis)
-      merge!(layout, d)
+    for x in pl.xaxis
+      x.xy = "x"
+      merge!(layout, Dict(x))
     end
   end
 
   if pl.yaxis !== nothing
-    for d in Dict.(pl.yaxis)
+    for y in pl.yaxis
+      y.xy = "y"
+      merge!(layout, Dict(y))
+    end
+  end
+
+  if pl.axes !== nothing
+    for d in Dict.(pl.axes)
       merge!(layout, d)
     end
   end


### PR DESCRIPTION
Although we do no longer develop our own implementation of Plots in favour of PlotlyBase, I feel that the current implementation of axes is confusing. (See #66 )

Currently, axis setting of the rendered PlotLayout is set by the xy field of PlotLayoutAxis and not by the keyword/field `xaxis`/`yaxis`.

I propose to change the rendering method such that we to chose the axis type according to the axis field so that
```julia
julia> render(PlotLayout(yaxis = [PlotLayoutAxis()]))
Dict{Symbol, Any} with 1 entry:
  :yaxis => Dict{Symbol, Any}()
```
For those who would want to keep the possibility to determine the axis type by the xy field, I have added a new keyword `axes` that keeps the behavior of former xaxis/yaxis.
```julia
julia> render(PlotLayout(axes = [PlotLayoutAxis(), PlotLayoutAxis(xy = "y")]))
Dict{Symbol, Any} with 2 entries:
  :xaxis => Dict{Symbol, Any}()
  :yaxis => Dict{Symbol, Any}()
```
