### PR TITLE
Remove "throw Error" since they cause other  components to fail silently

### DIFF
--- a/assets/js/vueplotly.min.js
+++ b/assets/js/vueplotly.min.js
@@ -18,7 +18,7 @@
             let boundAttribute = plotlyInstance.getAttribute(":"+attributeName);                    // Expected to be a valid js object (binding)
             // Both versions of attribute can't coexist
             if( literalAttribute != null && boundAttribute != null ){
-                throw new Error("Both bound and literal attribute found for " + attributeName + ". Only one is allowed.");
+                console.error("Both bound and literal attribute found for " + attributeName + ". Only one is allowed.");
             }
             // We don't need to do anything if there's a bound attribute (starting with ":", as it is assumed to be a valid JS object)
             if( boundAttribute != null ){
@@ -41,7 +41,7 @@
                         plotlyInstance.setAttribute(":"+attributeName, literalAttribute);           // Replace the original base64 data with the JS string
                         plotlyInstance.removeAttribute(attributeName);                              // Remove the original base64 attribute
                     }else{
-                        throw new Error("Invalid literal attribute for " + attributeName + ". Expected a base64-encoded JSON string, or a valid JS object.");
+                        console.error("Invalid literal attribute for " + attributeName + ". Expected a base64-encoded JSON string, or a valid JS object.");
                     }
                 }
             }


### PR DESCRIPTION
When a plotly element receives an undefined value in its attributes, like this:
`<plotly data="undefined">`

results in the component not being rendered in the page, but also causing other components to not be rendered, which is confusing for users. Removing the "throw Error" statements will allow the execution to continue with default or empty values.