### PR TITLE
add Plots extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,19 +13,23 @@ Stipple = "4acbeb90-81a0-11ea-1966-bdaff8155998"
 DataFrames = "1"
 Genie = "5.24.4"
 PlotlyBase = "0.8.19"
+Plots = "1.4"
 Requires = "1"
 Stipple = "0.29, 0.30"
 julia = "1.6"
 
 [extras]
 PlotlyBase = "a03496cd-edff-5a9b-9e67-9cda94a718b5"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [extensions]
 StipplePlotlyPlotlyBaseExt = "PlotlyBase"
+StipplePlotlyPlotsExt = ["Plots", "PlotlyBase"]
 
 [targets]
 test = ["Test", "PlotlyBase"]
 
 [weakdeps]
 PlotlyBase = "a03496cd-edff-5a9b-9e67-9cda94a718b5"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"

--- a/ext/StipplePlotlyPlotsExt.jl
+++ b/ext/StipplePlotlyPlotsExt.jl
@@ -1,0 +1,33 @@
+module StipplePlotlyPlotsExt
+
+using StipplePlotly
+using StipplePlotly.Stipple
+using StipplePlotly.Charts
+import Stipple: render, stipple_parse
+
+if isdefined(Base, :get_extension)
+    using Plots
+    using PlotlyBase
+else
+    using ..Plots
+    using ..PlotlyBase
+end
+
+function Stipple.render(pl::Plots.Plot)
+    pl = Plots.plotlybase_syncplot(pl)
+    delete!(pl.layout.fields, :height)
+    delete!(pl.layout.fields, :width)
+    pl.layout.fields[:margin] = Dict(:l => 50, :b => 50, :r => 50, :t => 60)
+
+    return pl
+end
+
+function __init__()
+    current_backend = Plots.backend()
+    if current_backend !== :plotly
+        Plots.plotly()
+        Plots.backend(current_backend)
+    end
+end
+
+end

--- a/ext/StipplePlotlyPlotsExt.jl
+++ b/ext/StipplePlotlyPlotsExt.jl
@@ -14,20 +14,20 @@ else
 end
 
 function Stipple.render(pl::Plots.Plot)
-    pl = Plots.plotlybase_syncplot(pl)
-    delete!(pl.layout.fields, :height)
-    delete!(pl.layout.fields, :width)
+    # make sure the PlotlyBase backend is loaded and that the current backend is not changed
+    already_initialized = true
+    if !isdefined(Plots, :plotlybase_syncplot)
+        current_backend = Plots.backend()
+        Plots.plotly() === current_backend || Plots.backend(current_backend)
+        already_initialized = false
+    end
+
+    pl = already_initialized ? Plots.plotlybase_syncplot(pl) : Base.invokelatest(Plots.plotlybase_syncplot, pl)
+    pop!(pl.layout, :height)
+    pop!(pl.layout, :width)
     pl.layout.fields[:margin] = Dict(:l => 50, :b => 50, :r => 50, :t => 60)
 
     return pl
-end
-
-function __init__()
-    current_backend = Plots.backend()
-    if current_backend !== :plotly
-        Plots.plotly()
-        Plots.backend(current_backend)
-    end
 end
 
 end


### PR DESCRIPTION
Referring to #13 I propose an additional extension that adds a render function for Plots. That way, we could also allow for
```julia
@app Example begin
    @out plot = Plots.plot(20:-1:1)
end

ui() = plotly(:plot)
```