### PR TITLE
Fix Base.hash to use only the two-arg method

### DIFF
--- a/src/Layouts.jl
+++ b/src/Layouts.jl
@@ -53,7 +53,7 @@ end
 
 Base.:(==)(x::Font, y::Font) = x.family == y.family && x.size == y.size && x.color == y.color
 
-Base.hash(f::Font) = hash("$(f.family)$(f.size)$(f.color)")
+Base.hash(f::Font, h::UInt) = hash("$(f.family)$(f.size)$(f.color)", h)
 
 Base.@kwdef mutable struct Protation
   lon::Union{Float64, Int64} = -234


### PR DESCRIPTION
Generated as part of an ecosystem-wide audit for one-arg hash methods.

`Base.hash` should only be extended via the two-arg method `hash(x, h::UInt)`.
Defining a one-arg `hash(x)` method, or giving the second argument a default
value, can lead to correctness bugs (hash contract violations when the seed
differs from the hard-coded default) and invalidation-related performance
issues. This is particularly necessary for Julia 1.13+ where the default hash
seed value will change.

This PR was generated with the assistance of generative AI.